### PR TITLE
Fix: Send admin password via X-Admin-Password header

### DIFF
--- a/email.sh
+++ b/email.sh
@@ -14,6 +14,5 @@ then
     formattedmessages=$formattedmessages'|'$i
   done
 
-  json='{"authenticationPassword":"'$EMAILAUTHPASS'", "messages" : "'$formattedmessages'"}'
-  curl -X POST -H "Content-Type: application/json" -d $json "https://api.voiceit.io/platform/41"
+  curl -X POST -H "X-Admin-Password: $EMAILAUTHPASS" --data-urlencode "messages=$formattedmessages" "https://api.voiceit.io/platform/41"
 fi


### PR DESCRIPTION
## Summary
- Moves `authenticationPassword` from JSON body to `X-Admin-Password` HTTP header
- Switches from JSON body to form-encoded params to match API 3 server's `@RequestParam` bindings

## Why
The API 3 server (Spring Boot) expects the admin password as an HTTP header, not a JSON body field. The previous approach would fail to authenticate against the new API.

Generated with [Claude Code](https://claude.com/claude-code)