### PR TITLE
Update internal references from VoiceIt2 to VoiceIt3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: objective-c
 podfile: Example/Podfile
-xcode_workspace: Example/VoiceIt2-IosSDK.xcworkspace
-xcode_scheme:  VoiceIt2-IosSDK-Example
+xcode_workspace: Example/VoiceIt3-IosSDK.xcworkspace
+xcode_scheme:  VoiceIt3-IosSDK-Example
 osx_image: xcode11.3
 xcode_destination: platform=iOS Simulator,OS=13.3,name=iPhone 8 Plus
 after_success:

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -1,12 +1,12 @@
 use_frameworks!
 
-target 'VoiceIt2-IosSDK_Example' do
+target 'VoiceIt3-IosSDK_Example' do
   platform :ios, '11.0'
-  pod 'VoiceIt2-IosSDK', :path => '../'
+  pod 'VoiceIt3-IosSDK', :path => '../'
 end
 
-target 'VoiceIt2-IosSDK_Test' do
+target 'VoiceIt3-IosSDK_Test' do
     platform :ios, '11.0'
     inherit! :search_paths
-    pod 'VoiceIt2-IosSDK', :path => '../'
+    pod 'VoiceIt3-IosSDK', :path => '../'
 end

--- a/Example/VoiceIt2-IosSDK.xcodeproj/project.pbxproj
+++ b/Example/VoiceIt2-IosSDK.xcodeproj/project.pbxproj
@@ -30,30 +30,30 @@
 			containerPortal = 6003F582195388D10070C39A /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = 6003F589195388D20070C39A;
-			remoteInfo = "VoiceIt2-IosSDK_Example";
+			remoteInfo = "VoiceIt3-IosSDK_Example";
 		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		05382F011FE0AECFA30B1489 /* Pods-VoiceIt2-IosSDK_Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-VoiceIt2-IosSDK_Example.debug.xcconfig"; path = "Target Support Files/Pods-VoiceIt2-IosSDK_Example/Pods-VoiceIt2-IosSDK_Example.debug.xcconfig"; sourceTree = "<group>"; };
+		05382F011FE0AECFA30B1489 /* Pods-VoiceIt3-IosSDK_Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-VoiceIt3-IosSDK_Example.debug.xcconfig"; path = "Target Support Files/Pods-VoiceIt3-IosSDK_Example/Pods-VoiceIt3-IosSDK_Example.debug.xcconfig"; sourceTree = "<group>"; };
 		0C71942D4AC44BCE60D27667 /* Pods_VoiceIt2_IosSDK_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_VoiceIt2_IosSDK_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		194FA0A2125801ED5593BF89 /* Pods-VoiceIt2-IosSDK_Test.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-VoiceIt2-IosSDK_Test.release.xcconfig"; path = "Target Support Files/Pods-VoiceIt2-IosSDK_Test/Pods-VoiceIt2-IosSDK_Test.release.xcconfig"; sourceTree = "<group>"; };
+		194FA0A2125801ED5593BF89 /* Pods-VoiceIt3-IosSDK_Test.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-VoiceIt3-IosSDK_Test.release.xcconfig"; path = "Target Support Files/Pods-VoiceIt3-IosSDK_Test/Pods-VoiceIt3-IosSDK_Test.release.xcconfig"; sourceTree = "<group>"; };
 		214EA546A31FA665667E4CC3 /* Pods_VoiceIt2_IosSDK_Test.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_VoiceIt2_IosSDK_Test.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		217DA1FE1E89A1EC00C918C5 /* InfoPlist.strings */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; path = InfoPlist.strings; sourceTree = "<group>"; };
-		2192DFF22133306E0078D2C9 /* VoiceIt2-IosSDK_Test.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "VoiceIt2-IosSDK_Test.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		2192DFF22133306E0078D2C9 /* VoiceIt3-IosSDK_Test.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "VoiceIt3-IosSDK_Test.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		2192DFF42133306E0078D2C9 /* VoiceIt2_IosSDK_Test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceIt2_IosSDK_Test.swift; sourceTree = "<group>"; };
 		2192DFF62133306E0078D2C9 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		2192DFFC213371C40078D2C9 /* VoiceItTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceItTestCase.swift; sourceTree = "<group>"; };
 		2192DFFE213372210078D2C9 /* TestHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestHelper.swift; sourceTree = "<group>"; };
-		39388264B1597DFC0CCDB71E /* VoiceIt2-IosSDK.podspec */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = "VoiceIt2-IosSDK.podspec"; path = "../VoiceIt2-IosSDK.podspec"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		39388264B1597DFC0CCDB71E /* VoiceIt3-IosSDK.podspec */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = "VoiceIt3-IosSDK.podspec"; path = "../VoiceIt3-IosSDK.podspec"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		49AA541CEE76F944758932B5 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = ../README.md; sourceTree = "<group>"; };
-		6003F58A195388D20070C39A /* VoiceIt2-IosSDK_Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "VoiceIt2-IosSDK_Example.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		6003F58A195388D20070C39A /* VoiceIt3-IosSDK_Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "VoiceIt3-IosSDK_Example.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		6003F58D195388D20070C39A /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		6003F58F195388D20070C39A /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
 		6003F591195388D20070C39A /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
-		6003F595195388D20070C39A /* VoiceIt2-IosSDK-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "VoiceIt2-IosSDK-Info.plist"; sourceTree = "<group>"; };
+		6003F595195388D20070C39A /* VoiceIt3-IosSDK-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "VoiceIt3-IosSDK-Info.plist"; sourceTree = "<group>"; };
 		6003F599195388D20070C39A /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
-		6003F59B195388D20070C39A /* VoiceIt2-IosSDK-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "VoiceIt2-IosSDK-Prefix.pch"; sourceTree = "<group>"; };
+		6003F59B195388D20070C39A /* VoiceIt3-IosSDK-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "VoiceIt3-IosSDK-Prefix.pch"; sourceTree = "<group>"; };
 		6003F59C195388D20070C39A /* VoiceItAppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = VoiceItAppDelegate.h; sourceTree = "<group>"; };
 		6003F59D195388D20070C39A /* VoiceItAppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = VoiceItAppDelegate.m; sourceTree = "<group>"; };
 		6003F5A5195388D20070C39A /* VoiceItViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = VoiceItViewController.h; sourceTree = "<group>"; };
@@ -63,8 +63,8 @@
 		71719F9E1E33DC2100824A3D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		854AE9EBAE4291439F1B6F9B /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = LICENSE; path = ../LICENSE; sourceTree = "<group>"; };
 		873B8AEA1B1F5CCA007FD442 /* Main.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = Main.storyboard; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
-		CD54CD3D92F7737FD4C005BA /* Pods-VoiceIt2-IosSDK_Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-VoiceIt2-IosSDK_Example.release.xcconfig"; path = "Target Support Files/Pods-VoiceIt2-IosSDK_Example/Pods-VoiceIt2-IosSDK_Example.release.xcconfig"; sourceTree = "<group>"; };
-		F42361D4AF75BAAE56BA315C /* Pods-VoiceIt2-IosSDK_Test.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-VoiceIt2-IosSDK_Test.debug.xcconfig"; path = "Target Support Files/Pods-VoiceIt2-IosSDK_Test/Pods-VoiceIt2-IosSDK_Test.debug.xcconfig"; sourceTree = "<group>"; };
+		CD54CD3D92F7737FD4C005BA /* Pods-VoiceIt3-IosSDK_Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-VoiceIt3-IosSDK_Example.release.xcconfig"; path = "Target Support Files/Pods-VoiceIt3-IosSDK_Example/Pods-VoiceIt3-IosSDK_Example.release.xcconfig"; sourceTree = "<group>"; };
+		F42361D4AF75BAAE56BA315C /* Pods-VoiceIt3-IosSDK_Test.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-VoiceIt3-IosSDK_Test.debug.xcconfig"; path = "Target Support Files/Pods-VoiceIt3-IosSDK_Test/Pods-VoiceIt3-IosSDK_Test.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -93,15 +93,15 @@
 		19A19428432DB4AF7F21D463 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				05382F011FE0AECFA30B1489 /* Pods-VoiceIt2-IosSDK_Example.debug.xcconfig */,
-				CD54CD3D92F7737FD4C005BA /* Pods-VoiceIt2-IosSDK_Example.release.xcconfig */,
-				F42361D4AF75BAAE56BA315C /* Pods-VoiceIt2-IosSDK_Test.debug.xcconfig */,
-				194FA0A2125801ED5593BF89 /* Pods-VoiceIt2-IosSDK_Test.release.xcconfig */,
+				05382F011FE0AECFA30B1489 /* Pods-VoiceIt3-IosSDK_Example.debug.xcconfig */,
+				CD54CD3D92F7737FD4C005BA /* Pods-VoiceIt3-IosSDK_Example.release.xcconfig */,
+				F42361D4AF75BAAE56BA315C /* Pods-VoiceIt3-IosSDK_Test.debug.xcconfig */,
+				194FA0A2125801ED5593BF89 /* Pods-VoiceIt3-IosSDK_Test.release.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
 		};
-		2192DFF32133306E0078D2C9 /* VoiceIt2-IosSDK_Test */ = {
+		2192DFF32133306E0078D2C9 /* VoiceIt3-IosSDK_Test */ = {
 			isa = PBXGroup;
 			children = (
 				2192DFFE213372210078D2C9 /* TestHelper.swift */,
@@ -109,15 +109,15 @@
 				2192DFF42133306E0078D2C9 /* VoiceIt2_IosSDK_Test.swift */,
 				2192DFF62133306E0078D2C9 /* Info.plist */,
 			);
-			path = "VoiceIt2-IosSDK_Test";
+			path = "VoiceIt3-IosSDK_Test";
 			sourceTree = "<group>";
 		};
 		6003F581195388D10070C39A = {
 			isa = PBXGroup;
 			children = (
 				60FF7A9C1954A5C5007DD14C /* Podspec Metadata */,
-				6003F593195388D20070C39A /* Example for VoiceIt2-IosSDK */,
-				2192DFF32133306E0078D2C9 /* VoiceIt2-IosSDK_Test */,
+				6003F593195388D20070C39A /* Example for VoiceIt3-IosSDK */,
+				2192DFF32133306E0078D2C9 /* VoiceIt3-IosSDK_Test */,
 				6003F58C195388D20070C39A /* Frameworks */,
 				6003F58B195388D20070C39A /* Products */,
 				19A19428432DB4AF7F21D463 /* Pods */,
@@ -127,8 +127,8 @@
 		6003F58B195388D20070C39A /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				6003F58A195388D20070C39A /* VoiceIt2-IosSDK_Example.app */,
-				2192DFF22133306E0078D2C9 /* VoiceIt2-IosSDK_Test.xctest */,
+				6003F58A195388D20070C39A /* VoiceIt3-IosSDK_Example.app */,
+				2192DFF22133306E0078D2C9 /* VoiceIt3-IosSDK_Test.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -146,7 +146,7 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
-		6003F593195388D20070C39A /* Example for VoiceIt2-IosSDK */ = {
+		6003F593195388D20070C39A /* Example for VoiceIt3-IosSDK */ = {
 			isa = PBXGroup;
 			children = (
 				6003F59C195388D20070C39A /* VoiceItAppDelegate.h */,
@@ -159,16 +159,16 @@
 				6003F5A8195388D20070C39A /* Images.xcassets */,
 				6003F594195388D20070C39A /* Supporting Files */,
 			);
-			name = "Example for VoiceIt2-IosSDK";
-			path = "VoiceIt2-IosSDK";
+			name = "Example for VoiceIt3-IosSDK";
+			path = "VoiceIt3-IosSDK";
 			sourceTree = "<group>";
 		};
 		6003F594195388D20070C39A /* Supporting Files */ = {
 			isa = PBXGroup;
 			children = (
-				6003F595195388D20070C39A /* VoiceIt2-IosSDK-Info.plist */,
+				6003F595195388D20070C39A /* VoiceIt3-IosSDK-Info.plist */,
 				6003F599195388D20070C39A /* main.m */,
-				6003F59B195388D20070C39A /* VoiceIt2-IosSDK-Prefix.pch */,
+				6003F59B195388D20070C39A /* VoiceIt3-IosSDK-Prefix.pch */,
 			);
 			name = "Supporting Files";
 			sourceTree = "<group>";
@@ -176,7 +176,7 @@
 		60FF7A9C1954A5C5007DD14C /* Podspec Metadata */ = {
 			isa = PBXGroup;
 			children = (
-				39388264B1597DFC0CCDB71E /* VoiceIt2-IosSDK.podspec */,
+				39388264B1597DFC0CCDB71E /* VoiceIt3-IosSDK.podspec */,
 				49AA541CEE76F944758932B5 /* README.md */,
 				854AE9EBAE4291439F1B6F9B /* LICENSE */,
 			);
@@ -186,9 +186,9 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
-		2192DFF12133306E0078D2C9 /* VoiceIt2-IosSDK_Test */ = {
+		2192DFF12133306E0078D2C9 /* VoiceIt3-IosSDK_Test */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 2192DFF92133306E0078D2C9 /* Build configuration list for PBXNativeTarget "VoiceIt2-IosSDK_Test" */;
+			buildConfigurationList = 2192DFF92133306E0078D2C9 /* Build configuration list for PBXNativeTarget "VoiceIt3-IosSDK_Test" */;
 			buildPhases = (
 				848020C274595A7D929647F7 /* [CP] Check Pods Manifest.lock */,
 				2192DFEE2133306E0078D2C9 /* Sources */,
@@ -201,14 +201,14 @@
 			dependencies = (
 				2192DFF82133306E0078D2C9 /* PBXTargetDependency */,
 			);
-			name = "VoiceIt2-IosSDK_Test";
-			productName = "VoiceIt2-IosSDK_Test";
-			productReference = 2192DFF22133306E0078D2C9 /* VoiceIt2-IosSDK_Test.xctest */;
+			name = "VoiceIt3-IosSDK_Test";
+			productName = "VoiceIt3-IosSDK_Test";
+			productReference = 2192DFF22133306E0078D2C9 /* VoiceIt3-IosSDK_Test.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
-		6003F589195388D20070C39A /* VoiceIt2-IosSDK_Example */ = {
+		6003F589195388D20070C39A /* VoiceIt3-IosSDK_Example */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 6003F5BF195388D20070C39A /* Build configuration list for PBXNativeTarget "VoiceIt2-IosSDK_Example" */;
+			buildConfigurationList = 6003F5BF195388D20070C39A /* Build configuration list for PBXNativeTarget "VoiceIt3-IosSDK_Example" */;
 			buildPhases = (
 				A6F8CFC638668B80488A1A1C /* [CP] Check Pods Manifest.lock */,
 				6003F586195388D20070C39A /* Sources */,
@@ -220,9 +220,9 @@
 			);
 			dependencies = (
 			);
-			name = "VoiceIt2-IosSDK_Example";
-			productName = "VoiceIt2-IosSDK";
-			productReference = 6003F58A195388D20070C39A /* VoiceIt2-IosSDK_Example.app */;
+			name = "VoiceIt3-IosSDK_Example";
+			productName = "VoiceIt3-IosSDK";
+			productReference = 6003F58A195388D20070C39A /* VoiceIt3-IosSDK_Example.app */;
 			productType = "com.apple.product-type.application";
 		};
 /* End PBXNativeTarget section */
@@ -248,7 +248,7 @@
 					};
 				};
 			};
-			buildConfigurationList = 6003F585195388D10070C39A /* Build configuration list for PBXProject "VoiceIt2-IosSDK" */;
+			buildConfigurationList = 6003F585195388D10070C39A /* Build configuration list for PBXProject "VoiceIt3-IosSDK" */;
 			compatibilityVersion = "Xcode 3.2";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
@@ -261,8 +261,8 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				6003F589195388D20070C39A /* VoiceIt2-IosSDK_Example */,
-				2192DFF12133306E0078D2C9 /* VoiceIt2-IosSDK_Test */,
+				6003F589195388D20070C39A /* VoiceIt3-IosSDK_Example */,
+				2192DFF12133306E0078D2C9 /* VoiceIt3-IosSDK_Test */,
 			);
 		};
 /* End PBXProject section */
@@ -295,16 +295,16 @@
 			files = (
 			);
 			inputPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-VoiceIt2-IosSDK_Test/Pods-VoiceIt2-IosSDK_Test-resources.sh",
-				"${PODS_CONFIGURATION_BUILD_DIR}/VoiceIt2-IosSDK/VoiceIt2-IosSDK.bundle",
+				"${PODS_ROOT}/Target Support Files/Pods-VoiceIt3-IosSDK_Test/Pods-VoiceIt3-IosSDK_Test-resources.sh",
+				"${PODS_CONFIGURATION_BUILD_DIR}/VoiceIt3-IosSDK/VoiceIt3-IosSDK.bundle",
 			);
 			name = "[CP] Copy Pods Resources";
 			outputPaths = (
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/VoiceIt2-IosSDK.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/VoiceIt3-IosSDK.bundle",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-VoiceIt2-IosSDK_Test/Pods-VoiceIt2-IosSDK_Test-resources.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-VoiceIt3-IosSDK_Test/Pods-VoiceIt3-IosSDK_Test-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		848020C274595A7D929647F7 /* [CP] Check Pods Manifest.lock */ = {
@@ -322,7 +322,7 @@
 			outputFileListPaths = (
 			);
 			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-VoiceIt2-IosSDK_Test-checkManifestLockResult.txt",
+				"$(DERIVED_FILE_DIR)/Pods-VoiceIt3-IosSDK_Test-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -335,16 +335,16 @@
 			files = (
 			);
 			inputPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-VoiceIt2-IosSDK_Example/Pods-VoiceIt2-IosSDK_Example-resources.sh",
-				"${PODS_CONFIGURATION_BUILD_DIR}/VoiceIt2-IosSDK/VoiceIt2-IosSDK.bundle",
+				"${PODS_ROOT}/Target Support Files/Pods-VoiceIt3-IosSDK_Example/Pods-VoiceIt3-IosSDK_Example-resources.sh",
+				"${PODS_CONFIGURATION_BUILD_DIR}/VoiceIt3-IosSDK/VoiceIt3-IosSDK.bundle",
 			);
 			name = "[CP] Copy Pods Resources";
 			outputPaths = (
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/VoiceIt2-IosSDK.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/VoiceIt3-IosSDK.bundle",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-VoiceIt2-IosSDK_Example/Pods-VoiceIt2-IosSDK_Example-resources.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-VoiceIt3-IosSDK_Example/Pods-VoiceIt3-IosSDK_Example-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		A6F8CFC638668B80488A1A1C /* [CP] Check Pods Manifest.lock */ = {
@@ -362,7 +362,7 @@
 			outputFileListPaths = (
 			);
 			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-VoiceIt2-IosSDK_Example-checkManifestLockResult.txt",
+				"$(DERIVED_FILE_DIR)/Pods-VoiceIt3-IosSDK_Example-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -397,7 +397,7 @@
 /* Begin PBXTargetDependency section */
 		2192DFF82133306E0078D2C9 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = 6003F589195388D20070C39A /* VoiceIt2-IosSDK_Example */;
+			target = 6003F589195388D20070C39A /* VoiceIt3-IosSDK_Example */;
 			targetProxy = 2192DFF72133306E0078D2C9 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
@@ -416,7 +416,7 @@
 /* Begin XCBuildConfiguration section */
 		2192DFFA2133306E0078D2C9 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = F42361D4AF75BAAE56BA315C /* Pods-VoiceIt2-IosSDK_Test.debug.xcconfig */;
+			baseConfigurationReference = F42361D4AF75BAAE56BA315C /* Pods-VoiceIt3-IosSDK_Test.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CLANG_ADDRESS_SANITIZER_CONTAINER_OVERFLOW = NO;
@@ -432,23 +432,23 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
-				INFOPLIST_FILE = "VoiceIt2-IosSDK_Test/Info.plist";
+				INFOPLIST_FILE = "VoiceIt3-IosSDK_Test/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = YES;
-				PRODUCT_BUNDLE_IDENTIFIER = "io.voiceit.VoiceIt2-IosSDK-Test";
+				PRODUCT_BUNDLE_IDENTIFIER = "io.voiceit.VoiceIt3-IosSDK-Test";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/VoiceIt2-IosSDK_Example.app/VoiceIt2-IosSDK_Example";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/VoiceIt3-IosSDK_Example.app/VoiceIt3-IosSDK_Example";
 			};
 			name = Debug;
 		};
 		2192DFFB2133306E0078D2C9 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 194FA0A2125801ED5593BF89 /* Pods-VoiceIt2-IosSDK_Test.release.xcconfig */;
+			baseConfigurationReference = 194FA0A2125801ED5593BF89 /* Pods-VoiceIt3-IosSDK_Test.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CLANG_ADDRESS_SANITIZER_CONTAINER_OVERFLOW = NO;
@@ -465,16 +465,16 @@
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				GCC_C_LANGUAGE_STANDARD = gnu11;
-				INFOPLIST_FILE = "VoiceIt2-IosSDK_Test/Info.plist";
+				INFOPLIST_FILE = "VoiceIt3-IosSDK_Test/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = NO;
-				PRODUCT_BUNDLE_IDENTIFIER = "io.voiceit.VoiceIt2-IosSDK-Test";
+				PRODUCT_BUNDLE_IDENTIFIER = "io.voiceit.VoiceIt3-IosSDK-Test";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/VoiceIt2-IosSDK_Example.app/VoiceIt2-IosSDK_Example";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/VoiceIt3-IosSDK_Example.app/VoiceIt3-IosSDK_Example";
 			};
 			name = Release;
 		};
@@ -584,7 +584,7 @@
 		};
 		6003F5C0195388D20070C39A /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 05382F011FE0AECFA30B1489 /* Pods-VoiceIt2-IosSDK_Example.debug.xcconfig */;
+			baseConfigurationReference = 05382F011FE0AECFA30B1489 /* Pods-VoiceIt3-IosSDK_Example.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "Apple Development";
@@ -593,8 +593,8 @@
 				DEVELOPMENT_TEAM = VS9YK7ML83;
 				GCC_NO_COMMON_BLOCKS = NO;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
-				GCC_PREFIX_HEADER = "VoiceIt2-IosSDK/VoiceIt2-IosSDK-Prefix.pch";
-				INFOPLIST_FILE = "VoiceIt2-IosSDK/VoiceIt2-IosSDK-Info.plist";
+				GCC_PREFIX_HEADER = "VoiceIt3-IosSDK/VoiceIt3-IosSDK-Prefix.pch";
+				INFOPLIST_FILE = "VoiceIt3-IosSDK/VoiceIt3-IosSDK-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				MARKETING_VERSION = 2.2.7;
 				MODULE_NAME = ExampleApp;
@@ -617,7 +617,7 @@
 		};
 		6003F5C1195388D20070C39A /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = CD54CD3D92F7737FD4C005BA /* Pods-VoiceIt2-IosSDK_Example.release.xcconfig */;
+			baseConfigurationReference = CD54CD3D92F7737FD4C005BA /* Pods-VoiceIt3-IosSDK_Example.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "Apple Development";
@@ -626,8 +626,8 @@
 				DEVELOPMENT_TEAM = VS9YK7ML83;
 				GCC_NO_COMMON_BLOCKS = NO;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
-				GCC_PREFIX_HEADER = "VoiceIt2-IosSDK/VoiceIt2-IosSDK-Prefix.pch";
-				INFOPLIST_FILE = "VoiceIt2-IosSDK/VoiceIt2-IosSDK-Info.plist";
+				GCC_PREFIX_HEADER = "VoiceIt3-IosSDK/VoiceIt3-IosSDK-Prefix.pch";
+				INFOPLIST_FILE = "VoiceIt3-IosSDK/VoiceIt3-IosSDK-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				MARKETING_VERSION = 2.2.7;
 				MODULE_NAME = ExampleApp;
@@ -651,7 +651,7 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		2192DFF92133306E0078D2C9 /* Build configuration list for PBXNativeTarget "VoiceIt2-IosSDK_Test" */ = {
+		2192DFF92133306E0078D2C9 /* Build configuration list for PBXNativeTarget "VoiceIt3-IosSDK_Test" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				2192DFFA2133306E0078D2C9 /* Debug */,
@@ -660,7 +660,7 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		6003F585195388D10070C39A /* Build configuration list for PBXProject "VoiceIt2-IosSDK" */ = {
+		6003F585195388D10070C39A /* Build configuration list for PBXProject "VoiceIt3-IosSDK" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				6003F5BD195388D20070C39A /* Debug */,
@@ -669,7 +669,7 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		6003F5BF195388D20070C39A /* Build configuration list for PBXNativeTarget "VoiceIt2-IosSDK_Example" */ = {
+		6003F5BF195388D20070C39A /* Build configuration list for PBXNativeTarget "VoiceIt3-IosSDK_Example" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				6003F5C0195388D20070C39A /* Debug */,

--- a/Example/VoiceIt2-IosSDK.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Example/VoiceIt2-IosSDK.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -2,6 +2,6 @@
 <Workspace
    version = "1.0">
    <FileRef
-      location = "self:VoiceIt2-IosSDK.xcodeproj">
+      location = "self:VoiceIt3-IosSDK.xcodeproj">
    </FileRef>
 </Workspace>

--- a/Example/VoiceIt2-IosSDK.xcodeproj/xcshareddata/xcschemes/VoiceIt2-IosSDK-Example.xcscheme
+++ b/Example/VoiceIt2-IosSDK.xcodeproj/xcshareddata/xcschemes/VoiceIt2-IosSDK-Example.xcscheme
@@ -15,9 +15,9 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "6003F589195388D20070C39A"
-               BuildableName = "VoiceIt2-IosSDK_Example.app"
-               BlueprintName = "VoiceIt2-IosSDK_Example"
-               ReferencedContainer = "container:VoiceIt2-IosSDK.xcodeproj">
+               BuildableName = "VoiceIt3-IosSDK_Example.app"
+               BlueprintName = "VoiceIt3-IosSDK_Example"
+               ReferencedContainer = "container:VoiceIt3-IosSDK.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
       </BuildActionEntries>
@@ -31,9 +31,9 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "6003F589195388D20070C39A"
-            BuildableName = "VoiceIt2-IosSDK_Example.app"
-            BlueprintName = "VoiceIt2-IosSDK_Example"
-            ReferencedContainer = "container:VoiceIt2-IosSDK.xcodeproj">
+            BuildableName = "VoiceIt3-IosSDK_Example.app"
+            BlueprintName = "VoiceIt3-IosSDK_Example"
+            ReferencedContainer = "container:VoiceIt3-IosSDK.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
       <Testables>
@@ -42,9 +42,9 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "2192DFF12133306E0078D2C9"
-               BuildableName = "VoiceIt2-IosSDK_Test.xctest"
-               BlueprintName = "VoiceIt2-IosSDK_Test"
-               ReferencedContainer = "container:VoiceIt2-IosSDK.xcodeproj">
+               BuildableName = "VoiceIt3-IosSDK_Test.xctest"
+               BlueprintName = "VoiceIt3-IosSDK_Test"
+               ReferencedContainer = "container:VoiceIt3-IosSDK.xcodeproj">
             </BuildableReference>
          </TestableReference>
       </Testables>
@@ -64,9 +64,9 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "6003F589195388D20070C39A"
-            BuildableName = "VoiceIt2-IosSDK_Example.app"
-            BlueprintName = "VoiceIt2-IosSDK_Example"
-            ReferencedContainer = "container:VoiceIt2-IosSDK.xcodeproj">
+            BuildableName = "VoiceIt3-IosSDK_Example.app"
+            BlueprintName = "VoiceIt3-IosSDK_Example"
+            ReferencedContainer = "container:VoiceIt3-IosSDK.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
       <EnvironmentVariables>
@@ -93,9 +93,9 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "6003F589195388D20070C39A"
-            BuildableName = "VoiceIt2-IosSDK_Example.app"
-            BlueprintName = "VoiceIt2-IosSDK_Example"
-            ReferencedContainer = "container:VoiceIt2-IosSDK.xcodeproj">
+            BuildableName = "VoiceIt3-IosSDK_Example.app"
+            BlueprintName = "VoiceIt3-IosSDK_Example"
+            ReferencedContainer = "container:VoiceIt3-IosSDK.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
    </ProfileAction>

--- a/Example/VoiceIt2-IosSDK.xcworkspace/contents.xcworkspacedata
+++ b/Example/VoiceIt2-IosSDK.xcworkspace/contents.xcworkspacedata
@@ -2,7 +2,7 @@
 <Workspace
    version = "1.0">
    <FileRef
-      location = "group:VoiceIt2-IosSDK.xcodeproj">
+      location = "group:VoiceIt3-IosSDK.xcodeproj">
    </FileRef>
    <FileRef
       location = "group:Pods/Pods.xcodeproj">

--- a/Example/VoiceIt2-IosSDK/VoiceItAppDelegate.h
+++ b/Example/VoiceIt2-IosSDK/VoiceItAppDelegate.h
@@ -1,6 +1,6 @@
 //
 //  VoiceItAppDelegate.h
-//  VoiceIt2-IosSDK
+//  VoiceIt3-IosSDK
 //
 //  Created by VoiceIt Technologies, LLC 
 //  Copyright (c) 2020 VoiceIt Technologies, LLC. All rights reserved.

--- a/Example/VoiceIt2-IosSDK/VoiceItAppDelegate.m
+++ b/Example/VoiceIt2-IosSDK/VoiceItAppDelegate.m
@@ -1,6 +1,6 @@
 //
 //  VoiceItAppDelegate.m
-//  VoiceIt2-IosSDK
+//  VoiceIt3-IosSDK
 //
 //  Created by VoiceIt Technologies LLC
 //  Copyright (c) 2020 VoiceIt Technologies, LLC. All rights reserved.

--- a/Example/VoiceIt2-IosSDK/VoiceItViewController.h
+++ b/Example/VoiceIt2-IosSDK/VoiceItViewController.h
@@ -1,6 +1,6 @@
 //
 //  VoiceItViewController.h
-//  VoiceIt2-IosSDK
+//  VoiceIt3-IosSDK
 //
 //  Created by VoiceIt Technologies, LLC 
 //  Copyright (c) 2020 VoiceIt Technologies, LLC. All rights reserved.

--- a/Example/VoiceIt2-IosSDK/VoiceItViewController.m
+++ b/Example/VoiceIt2-IosSDK/VoiceItViewController.m
@@ -1,6 +1,6 @@
 //
 //  VoiceItViewController.m
-//  VoiceIt2-IosSDK
+//  VoiceIt3-IosSDK
 //
 //  Created by VoiceIt Technologies, LLC
 //  Copyright (c) 2020 VoiceIt Technologies, LLC. All rights reserved.

--- a/Example/VoiceIt2-IosSDK/main.m
+++ b/Example/VoiceIt2-IosSDK/main.m
@@ -1,6 +1,6 @@
 //
 //  main.m
-//  VoiceIt2-IosSDK
+//  VoiceIt3-IosSDK
 //
 //  Created by VoiceIt Technologies, LLC 
 //  Copyright (c) 2020 VoiceIt Technologies, LLC. All rights reserved.

--- a/Example/VoiceIt2-IosSDK_Test/TestHelper.swift
+++ b/Example/VoiceIt2-IosSDK_Test/TestHelper.swift
@@ -1,6 +1,6 @@
 //
 //  TestHelper.swift
-//  VoiceIt2-IosSDK_Test
+//  VoiceIt3-IosSDK_Test
 //
 //  Created by VoiceIt Technologies, LLC
 //  Copyright (c) 2020 VoiceIt Technologies, LLC. All rights reserved.

--- a/Example/VoiceIt2-IosSDK_Test/VoiceIt2_IosSDK_Test.swift
+++ b/Example/VoiceIt2-IosSDK_Test/VoiceIt2_IosSDK_Test.swift
@@ -1,6 +1,6 @@
 //
-//  VoiceIt2-IosSDK_Test.swift
-//  VoiceIt2-IosSDK_Test
+//  VoiceIt3-IosSDK_Test.swift
+//  VoiceIt3-IosSDK_Test
 //
 //  Created by VoiceIt Technologies, LLC
 //  Copyright (c) 2020 VoiceIt Technologies, LLC. All rights reserved.

--- a/Example/VoiceIt2-IosSDK_Test/VoiceItTestCase.swift
+++ b/Example/VoiceIt2-IosSDK_Test/VoiceItTestCase.swift
@@ -1,6 +1,6 @@
 //
 //  VoiceItTestCase.swift
-//  VoiceIt2-IosSDK_Test
+//  VoiceIt3-IosSDK_Test
 //
 //  Created by VoiceIt Technologies, LLC
 //  Copyright (c) 2020 VoiceIt Technologies, LLC. All rights reserved.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-<img src="https://raw.githubusercontent.com/voiceittech/VoiceIt2-IosSDK/master/Graphics/ios.png" width="100%" style="width:100%">
+<img src="https://raw.githubusercontent.com/voiceittech/VoiceIt3-IosSDK/master/Graphics/ios.png" width="100%" style="width:100%">
 
-# VoiceIt2 iOS SDK [![Build Status](https://travis-ci.com/voiceittech/VoiceIt2-IosSDK.svg?branch=master)](https://travis-ci.com/voiceittech/VoiceIt2-IosSDK) [![version](https://img.shields.io/cocoapods/v/VoiceIt2-IosSDK.svg?style=flat)](http://cocoapods.org/pods/VoiceIt2-IosSDK) [![name](https://img.shields.io/cocoapods/p/VoiceIt2-IosSDK.svg?style=flat)](http://cocoapods.org/pods/VoiceIt2-IosSDK) ![MIT](https://img.shields.io/github/license/mashape/apistatus.svg)
+# VoiceIt2 iOS SDK [![Build Status](https://travis-ci.com/voiceittech/VoiceIt3-IosSDK.svg?branch=master)](https://travis-ci.com/voiceittech/VoiceIt3-IosSDK) [![version](https://img.shields.io/cocoapods/v/VoiceIt3-IosSDK.svg?style=flat)](http://cocoapods.org/pods/VoiceIt3-IosSDK) [![name](https://img.shields.io/cocoapods/p/VoiceIt3-IosSDK.svg?style=flat)](http://cocoapods.org/pods/VoiceIt3-IosSDK) ![MIT](https://img.shields.io/github/license/mashape/apistatus.svg)
 
 A fully comprehensive SDK that gives you access to VoiceIt's API 2.0 featuring Voice + Face Verification and Identification with built in user interfaces and liveness detection.
 
@@ -69,11 +69,11 @@ Contact us at <a href="mailto:support@voiceit.io" target="_blank">support@voicei
 
 ## Installation
 
-VoiceIt2-IosSDK is available through [CocoaPods](http://cocoapods.org). To install
+VoiceIt3-IosSDK is available through [CocoaPods](http://cocoapods.org). To install
 it, simply add the following line to your Podfile:
 
 ```ruby
-pod "VoiceIt2-IosSDK"
+pod "VoiceIt3-IosSDK"
 ```
 
 and then run pod install in your terminal
@@ -92,7 +92,7 @@ Also add the following permission keys to your <b>info.plist</b> file like shown
 ## Local Installation
 To run the SDK locally in your porject, please clone this repository, and specifiy the path in your podfile. For instance: 
 ```
-  pod "VoiceIt2-IosSDK", :path => './VoiceIt2-IosSDK'
+  pod "VoiceIt3-IosSDK", :path => './VoiceIt3-IosSDK'
 ```
 
 
@@ -114,7 +114,7 @@ Make sure you review your Voiceprint Phrases by navigating to <a href="https://d
 All strings utilized in the encapsulated views for the SDK and the prompts provided to the user can be modified by editing the strings in the Prompts.strings file located at
 
 ```
-Pods/VoiceIt2-IosSDK/Resources/Prompts.strings
+Pods/VoiceIt3-IosSDK/Resources/Prompts.strings
 ```
 You might have to unlock the Cocoapod to edit the file.
 
@@ -870,4 +870,4 @@ VoiceIt Technologies, <a href="mailto:support@voiceit.io" target="_blank">suppor
 
 ## License
 
-VoiceIt2-IosSDK is available under the MIT license. See the LICENSE file for more info.
+VoiceIt3-IosSDK is available under the MIT license. See the LICENSE file for more info.

--- a/VoiceIt2-IosSDK.podspec
+++ b/VoiceIt2-IosSDK.podspec
@@ -2,7 +2,7 @@
 #  Created by VoiceIt Technologies, LLC
 #  Copyright © 2020 VoiceIt Technologies LLC. All rights reserved.
 #
-# Be sure to run `pod lib lint VoiceIt2-IosSDK.podspec' to ensure this is a
+# Be sure to run `pod lib lint VoiceIt3-IosSDK.podspec' to ensure this is a
 # valid spec before submitting.
 #
 # Any lines starting with a # are optional, but their use is encouraged
@@ -10,7 +10,7 @@
 #
 
 Pod::Spec.new do |s|
-s.name             = 'VoiceIt2-IosSDK'
+s.name             = 'VoiceIt3-IosSDK'
 s.version          = '2.2.7'
 s.summary          = 'A pod that lets you add voice and face verification and identification to your iOS apps, brought to you by VoiceIt.'
 
@@ -21,17 +21,17 @@ s.summary          = 'A pod that lets you add voice and face verification and id
 #   * Finally, don't worry about the indent, CocoaPods strips it!
 
 s.description      = 'A pod that lets you add voice and face verification and identification to your iOS apps, brought to you by VoiceIt. Now also with basic liveness detection challenges. Please visit https://voiceit.io to learn more and sign up for an account.'
-s.homepage         = 'https://github.com/voiceittech/VoiceIt2-IosSDK'
+s.homepage         = 'https://github.com/voiceittech/VoiceIt3-IosSDK'
 s.license          = { :type => 'MIT', :file => 'LICENSE' }
 s.author           = { 'voiceit' => 'support@voiceit.io' }
-s.source           = { :git => 'https://github.com/voiceittech/VoiceIt2-IosSDK.git', :tag => s.version.to_s }
+s.source           = { :git => 'https://github.com/voiceittech/VoiceIt3-IosSDK.git', :tag => s.version.to_s }
 
 s.ios.deployment_target = '11.0'
 s.static_framework = true
-s.source_files = 'VoiceIt2-IosSDK/Classes/**/*.{h,m}','VoiceIt2-IosSDK/Assets/**/*.{wav}'
+s.source_files = 'VoiceIt3-IosSDK/Classes/**/*.{h,m}','VoiceIt3-IosSDK/Assets/**/*.{wav}'
 
 s.resource_bundles = {
-  'VoiceIt2-IosSDK' => ['VoiceIt2-IosSDK/Classes/**/*.{lproj,storyboard,xib,xcassets,strings}','VoiceIt2-IosSDK/Assets/**/*.{wav}']
+  'VoiceIt3-IosSDK' => ['VoiceIt3-IosSDK/Classes/**/*.{lproj,storyboard,xib,xcassets,strings}','VoiceIt3-IosSDK/Assets/**/*.{wav}']
 }
 
 s.frameworks = 'UIKit', 'AVFoundation'

--- a/VoiceIt2-IosSDK/Classes/Base.lproj/Prompts.strings
+++ b/VoiceIt2-IosSDK/Classes/Base.lproj/Prompts.strings
@@ -1,6 +1,6 @@
 
 //  Localizable.strings
-//  VoiceIt2-IosSDK
+//  VoiceIt3-IosSDK
 //
 //  Created by VoiceIt Technologies, LLC
 //  Copyright (c) 2020 VoiceIt Technologies, LLC. All rights reserved.

--- a/VoiceIt2-IosSDK/Classes/EnrollFinishViewController.h
+++ b/VoiceIt2-IosSDK/Classes/EnrollFinishViewController.h
@@ -1,6 +1,6 @@
 //
 //  EnrollFinishViewController.h
-//  VoiceIt2-IosSDK
+//  VoiceIt3-IosSDK
 //
 //  Created by VoiceIt Technologies, LLC
 //  Copyright © 2020 VoiceIt Technologies LLC. All rights reserved.

--- a/VoiceIt2-IosSDK/Classes/EnrollFinishViewController.m
+++ b/VoiceIt2-IosSDK/Classes/EnrollFinishViewController.m
@@ -1,6 +1,6 @@
 //
 //  EnrollFinishViewController.m
-//  VoiceIt2-IosSDK
+//  VoiceIt3-IosSDK
 //
 //  Created by VoiceIt Technologies, LLC 
 //  Copyright © 2020 VoiceIt Technologies LLC. All rights reserved.

--- a/VoiceIt2-IosSDK/Classes/EnrollSetupViewController.h
+++ b/VoiceIt2-IosSDK/Classes/EnrollSetupViewController.h
@@ -1,6 +1,6 @@
 //
 //  EnrollSetupViewController.h
-//  VoiceIt2-IosSDK
+//  VoiceIt3-IosSDK
 //
 //  Created by VoiceIt Technologies, LLC 
 //  Copyright © 2020 VoiceIt Technologies LLC. All rights reserved.

--- a/VoiceIt2-IosSDK/Classes/EnrollSetupViewController.m
+++ b/VoiceIt2-IosSDK/Classes/EnrollSetupViewController.m
@@ -1,6 +1,6 @@
 //
 //  EnrollSetupViewController.m
-//  VoiceIt2-IosSDK
+//  VoiceIt3-IosSDK
 //
 //  Created by VoiceIt Technologies, LLC 
 //  Copyright © 2020 VoiceIt Technologies LLC. All rights reserved.

--- a/VoiceIt2-IosSDK/Classes/FaceEnrollmentViewController.h
+++ b/VoiceIt2-IosSDK/Classes/FaceEnrollmentViewController.h
@@ -1,6 +1,6 @@
 //
 //  FaceEnrollmentViewController.h
-//  VoiceIt2-IosSDK
+//  VoiceIt3-IosSDK
 //
 //  Created by VoiceIt Technologies, LLC
 //  Copyright (c) 2020 VoiceIt Technologies, LLC. All rights reserved.

--- a/VoiceIt2-IosSDK/Classes/FaceEnrollmentViewController.m
+++ b/VoiceIt2-IosSDK/Classes/FaceEnrollmentViewController.m
@@ -1,6 +1,6 @@
 //
 //  FaceEnrollmentViewController.m
-//  VoiceIt2-IosSDK
+//  VoiceIt3-IosSDK
 //
 //  Created by VoiceIt Technologies, LLC
 //  Copyright (c) 2020 VoiceIt Technologies, LLC. All rights reserved.//

--- a/VoiceIt2-IosSDK/Classes/FaceVerificationViewController.h
+++ b/VoiceIt2-IosSDK/Classes/FaceVerificationViewController.h
@@ -1,6 +1,6 @@
 //
 //  FaceVerificationViewController.h
-//  VoiceIt2-IosSDK
+//  VoiceIt3-IosSDK
 //
 //  Created by VoiceIt Technologies, LLC
 //  Copyright (c) 2020 VoiceIt Technologies, LLC. All rights reserved.

--- a/VoiceIt2-IosSDK/Classes/FaceVerificationViewController.m
+++ b/VoiceIt2-IosSDK/Classes/FaceVerificationViewController.m
@@ -1,6 +1,6 @@
 //
 //  FaceVerificationViewController.m
-//  VoiceIt2-IosSDK
+//  VoiceIt3-IosSDK
 //
 //  Created by VoiceIt Technologies, LLC
 //  Copyright (c) 2020 VoiceIt Technologies, LLC. All rights reserved.
@@ -372,7 +372,7 @@ float initialBrightnessFV = 0.0;
             [self.player stop];
         });
         NSBundle * podBundle = [NSBundle bundleForClass: self.classForCoder];
-        NSURL * bundleURL = [[podBundle resourceURL] URLByAppendingPathComponent:@"VoiceIt2-IosSDK.bundle"];
+        NSURL * bundleURL = [[podBundle resourceURL] URLByAppendingPathComponent:@"VoiceIt3-IosSDK.bundle"];
         NSString* soundFilePath = [self.contentLanguage isEqualToString:@"es-ES"] ?
         [NSString stringWithFormat:@"%@/%@",[[[NSBundle alloc] initWithURL:bundleURL] resourcePath], [self getSpanishPrompts:lco]] : [NSString stringWithFormat:@"%@/%@",[[[NSBundle alloc] initWithURL:bundleURL] resourcePath], lco];
         NSURL *soundFileURL = [NSURL fileURLWithPath:soundFilePath];

--- a/VoiceIt2-IosSDK/Classes/MainNavigationController.h
+++ b/VoiceIt2-IosSDK/Classes/MainNavigationController.h
@@ -1,6 +1,6 @@
 //
 //  MainNavigationController.h
-//  VoiceIt2-IosSDK
+//  VoiceIt3-IosSDK
 //
 //  Created by VoiceIt Technologies, LLC
 //  Copyright (c) 2020 VoiceIt Technologies, LLC. All rights reserved.

--- a/VoiceIt2-IosSDK/Classes/MainNavigationController.m
+++ b/VoiceIt2-IosSDK/Classes/MainNavigationController.m
@@ -1,6 +1,6 @@
 //
 //  MainNavigationController.m
-//  VoiceIt2-IosSDK
+//  VoiceIt3-IosSDK
 //
 //  Created by VoiceIt Technologies, LLC
 //  Copyright (c) 2020 VoiceIt Technologies, LLC. All rights reserved.

--- a/VoiceIt2-IosSDK/Classes/ResponseManager.h
+++ b/VoiceIt2-IosSDK/Classes/ResponseManager.h
@@ -1,6 +1,6 @@
 //
 //  ResponseManager.h
-//  VoiceIt2-IosSDK
+//  VoiceIt3-IosSDK
 //
 //  Created by VoiceIt Technologies, LLC
 //  Copyright (c) 2020 VoiceIt Technologies, LLC. All rights reserved.

--- a/VoiceIt2-IosSDK/Classes/ResponseManager.m
+++ b/VoiceIt2-IosSDK/Classes/ResponseManager.m
@@ -1,6 +1,6 @@
 //
 //  ResponseManager.m
-//  VoiceIt2-IosSDK
+//  VoiceIt3-IosSDK
 //
 //  Created by VoiceIt Technologies, LLC
 //  Copyright (c) 2020 VoiceIt Technologies, LLC. All rights reserved.
@@ -11,7 +11,7 @@
 @implementation ResponseManager
 +(NSString *)getMessage:(NSString*) name{
     NSBundle * podBundle = [NSBundle bundleForClass: self.classForCoder];
-    NSURL * bundleURL = [[podBundle resourceURL] URLByAppendingPathComponent:@"VoiceIt2-IosSDK.bundle"];
+    NSURL * bundleURL = [[podBundle resourceURL] URLByAppendingPathComponent:@"VoiceIt3-IosSDK.bundle"];
     NSBundle  * bundle = [[NSBundle alloc] initWithURL:bundleURL];
     NSString *finalString = NSLocalizedStringFromTableInBundle(name, @"Prompts", bundle, nil);
     //    NSString *finalString = NSLocalizedString(name, nil);
@@ -20,7 +20,7 @@
 
 +(NSString *)getMessage:(NSString*) name variable:(NSString*)variable{
     NSBundle * podBundle = [NSBundle bundleForClass: self.classForCoder];
-    NSURL * bundleURL = [[podBundle resourceURL] URLByAppendingPathComponent:@"VoiceIt2-IosSDK.bundle"];
+    NSURL * bundleURL = [[podBundle resourceURL] URLByAppendingPathComponent:@"VoiceIt3-IosSDK.bundle"];
     NSBundle  * bundle = [[NSBundle alloc] initWithURL:bundleURL];
     NSString *finalString = [[NSString alloc] initWithFormat: NSLocalizedStringFromTableInBundle(name, @"Prompts", bundle, nil) ,variable];
     return finalString;

--- a/VoiceIt2-IosSDK/Classes/SpinningView.h
+++ b/VoiceIt2-IosSDK/Classes/SpinningView.h
@@ -1,6 +1,6 @@
 //
 //  SpinningView.h
-//  VoiceIt2-IosSDK
+//  VoiceIt3-IosSDK
 //
 //  Created by VoiceIt Technologies, LLC
 //  Copyright (c) 2020 VoiceIt Technologies, LLC. All rights reserved.

--- a/VoiceIt2-IosSDK/Classes/SpinningView.m
+++ b/VoiceIt2-IosSDK/Classes/SpinningView.m
@@ -1,6 +1,6 @@
 //
 //  SpinningView.m
-//  VoiceIt2-IosSDK
+//  VoiceIt3-IosSDK
 //
 //  Created by VoiceIt Technologies, LLC
 //  Copyright (c) 2020 VoiceIt Technologies, LLC. All rights reserved.

--- a/VoiceIt2-IosSDK/Classes/Styles.h
+++ b/VoiceIt2-IosSDK/Classes/Styles.h
@@ -1,6 +1,6 @@
 //
 //  Styles.h
-//  VoiceIt2-IosSDK
+//  VoiceIt3-IosSDK
 //
 //  Created by VoiceIt Technologies, LLC
 //  Copyright (c) 2020 VoiceIt Technologies, LLC. All rights reserved.

--- a/VoiceIt2-IosSDK/Classes/Styles.m
+++ b/VoiceIt2-IosSDK/Classes/Styles.m
@@ -1,6 +1,6 @@
 //
 //  Styles.m
-//  VoiceIt2-IosSDK
+//  VoiceIt3-IosSDK
 //
 //  Created by VoiceIt Technologies, LLC
 //  Copyright (c) 2020 VoiceIt Technologies, LLC. All rights reserved.

--- a/VoiceIt2-IosSDK/Classes/Utilities.h
+++ b/VoiceIt2-IosSDK/Classes/Utilities.h
@@ -1,6 +1,6 @@
 //
 //  Utilities.h
-//  VoiceIt2-IosSDK
+//  VoiceIt3-IosSDK
 //
 //  Created by VoiceIt Technologies, LLC
 //  Copyright (c) 2020 VoiceIt Technologies, LLC. All rights reserved.

--- a/VoiceIt2-IosSDK/Classes/Utilities.m
+++ b/VoiceIt2-IosSDK/Classes/Utilities.m
@@ -1,6 +1,6 @@
 //
 //  Utilities.m
-//  VoiceIt2-IosSDK
+//  VoiceIt3-IosSDK
 //
 //  Created by VoiceIt Technologies, LLC
 //  Copyright (c) 2020 VoiceIt Technologies, LLC. All rights reserved.
@@ -57,7 +57,7 @@
 
 +(UIStoryboard *)getVoiceItStoryBoard{
     NSBundle * podBundle = [NSBundle bundleForClass: self.classForCoder];
-    NSURL * bundleURL = [[podBundle resourceURL] URLByAppendingPathComponent:@"VoiceIt2-IosSDK.bundle"];
+    NSURL * bundleURL = [[podBundle resourceURL] URLByAppendingPathComponent:@"VoiceIt3-IosSDK.bundle"];
     NSBundle  * bundle = [[NSBundle alloc] initWithURL:bundleURL];
     UIStoryboard *voiceItStoryboard = [UIStoryboard storyboardWithName:@"VoiceIt" bundle: bundle];
     return voiceItStoryboard;

--- a/VoiceIt2-IosSDK/Classes/VideoEnrollmentViewController.h
+++ b/VoiceIt2-IosSDK/Classes/VideoEnrollmentViewController.h
@@ -1,6 +1,6 @@
 //
 //  VideoEnrollmentViewController.h
-//  VoiceIt2-IosSDK
+//  VoiceIt3-IosSDK
 //
 //  Created by VoiceIt Technologies, LLC
 //  Copyright (c) 2020 VoiceIt Technologies, LLC. All rights reserved.

--- a/VoiceIt2-IosSDK/Classes/VideoEnrollmentViewController.m
+++ b/VoiceIt2-IosSDK/Classes/VideoEnrollmentViewController.m
@@ -1,6 +1,6 @@
 //
 //  VideoEnrollmentViewController.m
-//  VoiceIt2-IosSDK
+//  VoiceIt3-IosSDK
 //
 //  Created by VoiceIt Technologies, LLC
 //  Copyright (c) 2020 VoiceIt Technologies, LLC. All rights reserved.

--- a/VoiceIt2-IosSDK/Classes/VideoVerificationViewController.h
+++ b/VoiceIt2-IosSDK/Classes/VideoVerificationViewController.h
@@ -1,6 +1,6 @@
 //
 //  VideoVerificationViewController.h
-//  VoiceIt2-IosSDK
+//  VoiceIt3-IosSDK
 //
 //  Created by VoiceIt Technologies, LLC
 //  Copyright (c) 2020 VoiceIt Technologies, LLC. All rights reserved.

--- a/VoiceIt2-IosSDK/Classes/VideoVerificationViewController.m
+++ b/VoiceIt2-IosSDK/Classes/VideoVerificationViewController.m
@@ -1,6 +1,6 @@
 //
 //  VideoVerificationViewController.m
-//  VoiceIt2-IosSDK
+//  VoiceIt3-IosSDK
 //
 //  Created by VoiceIt Technologies, LLC
 //  Copyright (c) 2020 VoiceIt Technologies, LLC. All rights reserved.
@@ -402,7 +402,7 @@ float initialBrightnessVV = 0.0;
             [self.player stop];
         });
         NSBundle * podBundle = [NSBundle bundleForClass: self.classForCoder];
-        NSURL * bundleURL = [[podBundle resourceURL] URLByAppendingPathComponent:@"VoiceIt2-IosSDK.bundle"];
+        NSURL * bundleURL = [[podBundle resourceURL] URLByAppendingPathComponent:@"VoiceIt3-IosSDK.bundle"];
         NSString* soundFilePath = [self.contentLanguage isEqualToString:@"es-ES"] ?
         [NSString stringWithFormat:@"%@/%@",[[[NSBundle alloc] initWithURL:bundleURL] resourcePath], [self getSpanishPrompts:lco]] : [NSString stringWithFormat:@"%@/%@",[[[NSBundle alloc] initWithURL:bundleURL] resourcePath], lco];
         NSURL *soundFileURL = [NSURL fileURLWithPath:soundFilePath];

--- a/VoiceIt2-IosSDK/Classes/VoiceEnrollmentViewController.h
+++ b/VoiceIt2-IosSDK/Classes/VoiceEnrollmentViewController.h
@@ -1,6 +1,6 @@
 //
 //  VoiceEnrollmentViewController.h
-//  VoiceIt2-IosSDK
+//  VoiceIt3-IosSDK
 //
 //  Created by VoiceIt Technologies, LLC
 //  Copyright (c) 2020 VoiceIt Technologies, LLC. All rights reserved.

--- a/VoiceIt2-IosSDK/Classes/VoiceEnrollmentViewController.m
+++ b/VoiceIt2-IosSDK/Classes/VoiceEnrollmentViewController.m
@@ -1,6 +1,6 @@
 //
 //  VoiceEnrollmentViewController.m
-//  VoiceIt2-IosSDK
+//  VoiceIt3-IosSDK
 //
 //  Created by VoiceIt Technologies, LLC
 //  Copyright (c) 2020 VoiceIt Technologies, LLC. All rights reserved.

--- a/VoiceIt2-IosSDK/Classes/VoiceIdentificationViewController.h
+++ b/VoiceIt2-IosSDK/Classes/VoiceIdentificationViewController.h
@@ -1,6 +1,6 @@
 //
 //  VoiceIdentificationViewController.h
-//  VoiceIt2-IosSDK
+//  VoiceIt3-IosSDK
 //
 //  Created by VoiceIt Technologies, LLC
 //  Copyright (c) 2020 VoiceIt Technologies, LLC. All rights reserved.

--- a/VoiceIt2-IosSDK/Classes/VoiceIdentificationViewController.m
+++ b/VoiceIt2-IosSDK/Classes/VoiceIdentificationViewController.m
@@ -1,6 +1,6 @@
 //
 //  VoiceIdentificationViewController.m
-//  VoiceIt2-IosSDK
+//  VoiceIt3-IosSDK
 //
 //  Created by VoiceIt Technologies, LLC
 //  Copyright (c) 2020 VoiceIt Technologies, LLC. All rights reserved.

--- a/VoiceIt2-IosSDK/Classes/VoiceItAPITwo.h
+++ b/VoiceIt2-IosSDK/Classes/VoiceItAPITwo.h
@@ -1,6 +1,6 @@
 //
 //  VoiceItAPITwo.h
-//  VoiceIt2-IosSDK
+//  VoiceIt3-IosSDK
 //
 //  Created by VoiceIt Technologies, LLC
 //  Copyright (c) 2020 VoiceIt Technologies, LLC. All rights reserved.

--- a/VoiceIt2-IosSDK/Classes/VoiceItAPITwo.m
+++ b/VoiceIt2-IosSDK/Classes/VoiceItAPITwo.m
@@ -1,6 +1,6 @@
 //
 //  VoiceItAPITwo.m
-//  VoiceIt2-IosSDK
+//  VoiceIt3-IosSDK
 //
 //  Created by VoiceIt Technologies, LLC
 //  Copyright (c) 2020 VoiceIt Technologies, LLC. All rights reserved.

--- a/VoiceIt2-IosSDK/Classes/VoiceItLogo.h
+++ b/VoiceIt2-IosSDK/Classes/VoiceItLogo.h
@@ -1,6 +1,6 @@
 //
 //  VoiceItLogo.h
-//  VoiceIt2-IosSDK
+//  VoiceIt3-IosSDK
 //
 //  Created by VoiceIt Technologies, LLC
 //  Copyright (c) 2020 VoiceIt Technologies, LLC. All rights reserved.

--- a/VoiceIt2-IosSDK/Classes/VoiceItLogo.m
+++ b/VoiceIt2-IosSDK/Classes/VoiceItLogo.m
@@ -1,6 +1,6 @@
 //
 //  VoiceItLogo.m
-//  VoiceIt2-IosSDK
+//  VoiceIt3-IosSDK
 //
 //  Created by VoiceIt Technologies, LLC
 //  Copyright (c) 2020 VoiceIt Technologies, LLC. All rights reserved.

--- a/VoiceIt2-IosSDK/Classes/VoiceVerificationViewController.h
+++ b/VoiceIt2-IosSDK/Classes/VoiceVerificationViewController.h
@@ -1,6 +1,6 @@
 //
 //  VoiceVerificationViewController.h
-//  VoiceIt2-IosSDK
+//  VoiceIt3-IosSDK
 //
 //  Created by VoiceIt Technologies, LLC
 //  Copyright (c) 2020 VoiceIt Technologies, LLC. All rights reserved.

--- a/VoiceIt2-IosSDK/Classes/VoiceVerificationViewController.m
+++ b/VoiceIt2-IosSDK/Classes/VoiceVerificationViewController.m
@@ -1,6 +1,6 @@
 //
 //  VoiceVerificationViewController.m
-//  VoiceIt2-IosSDK
+//  VoiceIt3-IosSDK
 //
 //  Created by VoiceIt Technologies, LLC
 //  Copyright (c) 2020 VoiceIt Technologies, LLC. All rights reserved.


### PR DESCRIPTION
## Summary
- Repo has been renamed from VoiceIt2-* to VoiceIt3-*.
- Updated all internal references (URLs, package names, paths) to use VoiceIt3- instead of VoiceIt2-.

## Test plan
- [ ] Verify builds/tests pass with updated references
- [ ] Confirm all links point to correct VoiceIt3-* repositories

🤖 Generated with [Claude Code](https://claude.com/claude-code)