### PR TITLE
Remove liveness server references and LCO flow

### DIFF
--- a/VoiceIt2-IosSDK.podspec
+++ b/VoiceIt2-IosSDK.podspec
@@ -20,7 +20,7 @@ s.summary          = 'A pod that lets you add voice and face verification and id
 #   * Write the description between the DESC delimiters below.
 #   * Finally, don't worry about the indent, CocoaPods strips it!
 
-s.description      = 'A pod that lets you add voice and face verification and identification to your iOS apps, brought to you by VoiceIt. Now also with basic liveness detection challenges. Please visit https://voiceit.io to learn more and sign up for an account.'
+s.description      = 'A pod that lets you add voice and face verification and identification to your iOS apps, brought to you by VoiceIt. Please visit https://voiceit.io to learn more and sign up for an account.'
 s.homepage         = 'https://github.com/voiceittech/VoiceIt3-IosSDK'
 s.license          = { :type => 'MIT', :file => 'LICENSE' }
 s.author           = { 'voiceit' => 'support@voiceit.io' }

--- a/VoiceIt2-IosSDK/Classes/Base.lproj/Prompts.strings
+++ b/VoiceIt2-IosSDK/Classes/Base.lproj/Prompts.strings
@@ -74,14 +74,6 @@
 "GERR"= "Sorry, something went wrong.\nPlease try again.";
 "CONTACT_DEVELOPER" = "Error:\n Please contact app developer with response code \"%@\".";
 
-/* Liveness Prompts */
-"SMILE" = "Please smile into the camera";
-"BLINK" = "Please blink three times";
-"FACE_LEFT" = "Please turn your face to the left and back";
-"FACE_RIGHT" = "Please turn your face to the right and back";
-"LIVENESS_SUCCESS" = "Challenge passed!";
-"LIVENESS_TRY_AGAIN" = "Failed liveness! Please try again";
-
 /* Error Handling */
 "NETWORK_ERROR" = "Please make sure you are connected to the internet";
 "CREDENTIAL_ERROR" = "Please make sure your userId and credentials are correct";

--- a/VoiceIt2-IosSDK/Classes/FaceVerificationViewController.h
+++ b/VoiceIt2-IosSDK/Classes/FaceVerificationViewController.h
@@ -34,25 +34,20 @@
 @property(nonatomic, strong) dispatch_queue_t videoDataOutputQueue;
 @property(nonatomic, strong) AVCaptureVideoPreviewLayer * previewLayer;
 @property (nonatomic, strong) NSData * finalCapturedPhotoData;
-@property (nonatomic,strong) AVAudioPlayer * player;
 
 #pragma mark -  Boolean Switches
 @property BOOL lookingIntoCam;
 @property BOOL isRecording;
 @property BOOL continueRunning;
-@property BOOL doLivenessDetection;
-@property BOOL doAudioPrompts;
 @property BOOL verificationStarted;
 @property BOOL isReadyToWrite;
 @property BOOL imageIsSaved;
-@property BOOL cancelPlayback;
 
 #pragma mark -  Counters to keep track of stuff
 @property int lookingIntoCamCounter;
 @property int failCounter;
 @property int failsAllowed;
 @property int error;
-@property int numberOfLivenessFailsAllowed;
 
 #pragma mark -  Developer Passed Options
 @property (strong, nonatomic) NSString * userToVerifyUserId;
@@ -63,7 +58,4 @@
 @property (nonatomic, copy) void (^userVerificationCancelled)(void);
 @property (nonatomic, copy) void (^userVerificationSuccessful)( float, NSString *);
 @property (nonatomic, copy) void (^userVerificationFailed)( float, NSString *);
-
-@property (nonatomic, copy) void (^userVerificationSuccessfulWithLiveness)(NSString *);
-@property (nonatomic, copy) void (^userVerificationFailedWithLiveness)(NSString *);
 @end

--- a/VoiceIt2-IosSDK/Classes/VideoVerificationViewController.h
+++ b/VoiceIt2-IosSDK/Classes/VideoVerificationViewController.h
@@ -12,7 +12,7 @@
 #import "ResponseManager.h"
 #import "VoiceItAPITwo.h"
 
-@interface VideoVerificationViewController : UIViewController <AVCaptureMetadataOutputObjectsDelegate,AVCaptureVideoDataOutputSampleBufferDelegate,AVAudioRecorderDelegate,AVCaptureFileOutputRecordingDelegate>
+@interface VideoVerificationViewController : UIViewController <AVCaptureMetadataOutputObjectsDelegate,AVCaptureVideoDataOutputSampleBufferDelegate,AVAudioRecorderDelegate>
 
 @property (weak, nonatomic) IBOutlet UIButton *cancelButton;
 
@@ -34,25 +34,19 @@
 @property (nonatomic, strong) dispatch_queue_t videoDataOutputQueue;
 @property (nonatomic, strong) AVCaptureVideoPreviewLayer * previewLayer;
 @property (nonatomic, strong) NSData * finalCapturedPhotoData;
-@property (nonatomic, strong) AVAudioPlayer * player;
-@property AVCaptureMovieFileOutput * movieFileOutput;
 
 #pragma mark -  Boolean Switches
 @property BOOL lookingIntoCam;
 @property BOOL isRecording;
 @property BOOL continueRunning;
-@property BOOL doLivenessDetection;
-@property BOOL doAudioPrompts;
 @property BOOL verificationStarted;
 @property BOOL isReadyToWrite;
 @property BOOL imageIsSaved;
-@property BOOL cancelPlayback;
 
 #pragma mark -  Counters to keep track of stuff
 @property int lookingIntoCamCounter;
 @property int failCounter;
 @property int failsAllowed;
-@property int numberOfLivenessFailsAllowed;
 
 #pragma mark -  Developer Passed Options
 @property (strong, nonatomic) NSString * userToVerifyUserId;
@@ -69,7 +63,4 @@
 @property (nonatomic, copy) void (^userVerificationCancelled)(void);
 @property (nonatomic, copy) void (^userVerificationSuccessful)(float, float, NSString *);
 @property (nonatomic, copy) void (^userVerificationFailed)(float, float, NSString *);
-
-@property (nonatomic, copy) void (^userVerificationSuccessfulWithLiveness)(NSString *);
-@property (nonatomic, copy) void (^userVerificationFailedWithLiveness)(NSString *);
 @end

--- a/VoiceIt2-IosSDK/Classes/VideoVerificationViewController.m
+++ b/VoiceIt2-IosSDK/Classes/VideoVerificationViewController.m
@@ -19,23 +19,9 @@
 @property CGFloat backgroundWidthHeight;
 @property NSTimer * timer;
 
-@property int currentChallenge;
-@property NSNumber * livenessChallengeTime;
-@property BOOL isChallengeRetrieved;
-
-@property NSString * lcoId;
-@property NSArray * lcoStrings;
-@property NSArray * lco;
-
 @property NSString * result;
-@property NSString * uiMessage;
-@property NSString * livenessInstruction;
-@property NSString * audioPromptType;
 
-@property BOOL isSuccess;
 @property BOOL isProcessing;
-
-@property BOOL success;
 @end
 
 float initialBrightnessVV = 0.0;
@@ -73,27 +59,19 @@ float initialBrightnessVV = 0.0;
     self.continueRunning = YES;
     self.verificationStarted = NO;
     self.failCounter = 0;
-    self.cancelPlayback = NO;
 
     self.isProcessing = NO;
     self.isReadyToWrite = NO;
 
     self.imageIsSaved = NO;
-    
-    self.isSuccess = NO;
-    
+
     // Do any additional setup after loading the view.
     [self.progressView setHidden:YES];
-    
-    if([self doLivenessDetection]){
-        //Get LCOID, challenge string and liveness time
-        [self getLivenessData];
-    } else{
-        // Set up the AVCapture Session
-        [self setupCaptureSession];
-        [self setupVideoProcessing];
-        [self setupScreen];
-    }
+
+    // Set up the AVCapture Session
+    [self setupCaptureSession];
+    [self setupVideoProcessing];
+    [self setupScreen];
 }
 
 -(void) viewWillAppear:(BOOL)animated{
@@ -130,126 +108,6 @@ float initialBrightnessVV = 0.0;
             [self userVerificationFailed](0.0, 0.0, jsonResponse);
         }];
     });
-}
-
-#pragma mark - Liveness Data
-
--(void) handleLivenessResponse: (NSString*)result{
-    NSLog(@"Handle Liveness Response");
-    NSDictionary *jsonObj = [Utilities getJSONObject:result];
-    self.uiMessage = [jsonObj objectForKey:@"uiMessage"];
-    BOOL retry = [[jsonObj objectForKey:@"retry"] boolValue];
-    self.success = [[jsonObj objectForKey:@"success"] boolValue];
-    self.audioPromptType = [jsonObj objectForKey:@"audioPrompt"];
-    self.result = result;
-    
-    // Remove the video file created on last pass
-    [Utilities deleteFile:self.videoPath];
-    // Remove rotating circle
-    [self removeUploadingCircle];
-
-    // Failed Liveness and need to retry
-    if(!self.success && retry){
-        NSLog(@"Liveness Failed and Retry is True : result : %@", result);
-        // Play LCO Failed Audio File
-        [self playSound:self.audioPromptType];
-        // Display message on UI
-        dispatch_async(dispatch_get_main_queue(), ^{
-            [self.messageLabel setText:self.uiMessage];
-        });
-        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 3.0 * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
-            [self startRecordingVideo];
-        });
-    }
-
-    // Failed liveness all attempts now exit back to app
-    if(!self.success && !retry){
-        NSLog(@"Liveness Failed and Retry is False : result : %@", result);
-        // Play LCO Failed Audio File
-        [self playSound:self.audioPromptType];
-        // Display message on UI
-        dispatch_async(dispatch_get_main_queue(), ^{
-            [self.messageLabel setText:self.uiMessage];
-        });
-        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 3.0 * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
-            [self dismissViewControllerAnimated: YES completion:^{
-                [self userVerificationFailed](0.0, 0.0, self.uiMessage);
-            }];
-        });
-    }
-    
-    // Passed Liveness and Passed API 3 Verification
-    if(self.success){
-        NSLog(@"Liveness Passed and Retry is False : result : %@", self.uiMessage);
-        dispatch_async(dispatch_get_main_queue(), ^{
-            [self.messageLabel setText:self.uiMessage];
-            // Hide Button
-            [self.cancelButton setHidden:YES];
-        });
-        
-        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 3.0 * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
-            [self dismissViewControllerAnimated: YES completion:^{
-                [self userVerificationSuccessful](0.0, 0.0, self.uiMessage);
-            }];
-        });
-        [self playSound:self.audioPromptType];
-    }
-}
-
--(void) getLivenessData{
-    NSLog(@"Get Liveness Data");
-    if(!self.doLivenessDetection) return;
-    
-    [[self myVoiceIt] getLivenessID:self.userToVerifyUserId countryCode:
-     self.contentLanguage callback:^(NSString *response) {
-        
-        NSDictionary *data = [Utilities getJSONObject:response];
-        self.lcoStrings = [data valueForKey:@"lcoStrings"];
-        self.isChallengeRetrieved = [data valueForKey:@"success"];
-        self.lcoId = [data valueForKey:@"lcoId"];
-        self.livenessChallengeTime = [data valueForKey:@"livenessChallengeTime"];
-        self.lco = [data valueForKey:@"lco"];
-        self.livenessInstruction = [data valueForKey:@"uiLivenessInstruction"];
-        dispatch_async(dispatch_get_main_queue(), ^{
-            [self setupCaptureSession];
-            [self setupVideoProcessing];
-            [self setupScreen];
-        });
-    } onFailed:^(NSError * error) {
-        dispatch_async(dispatch_get_main_queue(), ^{
-            [self.messageLabel setText: @"Liveness service failed. Please Try again Later."];
-            [self.cancelButton setTitle:@"Cancel" forState:UIControlStateNormal];
-        });
-    } pageCateory:@"verification"];
-}
-
--(void) setLivenessChallengeMessages{
-    NSLog(@"Set Liveness Challenge Message");
-    if (!self.continueRunning) {
-        return;
-    }
-    // Record time from liveness server + 5 seconds of Audio
-    float timeToStop = [self.livenessChallengeTime floatValue] + 5.0;
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, timeToStop * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
-        [self.movieFileOutput stopRecording];
-        [self stopRecordingAudio];
-        [self clearCircleAnimations];
-        [self.messageLabel setText:@""];
-        [self showUploadingCircle];
-    });
-    
-    [self setMessage:[self.lcoStrings firstObject]];
-    dispatch_async(dispatch_get_main_queue(), ^{
-        [self illuminateLivenessChallengeOnCircle:[self.lco firstObject]];
-    });
-    
-    for(int i=1;i<self.lco.count;i++){
-        float time = [self.livenessChallengeTime floatValue]/(self.lco.count);
-        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, time * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
-            [self setMessage:self.lcoStrings[i]];
-            [self illuminateLivenessChallengeOnCircle:self.lco[i]];
-        });
-    }
 }
 
 #pragma mark - Setup Methods
@@ -300,38 +158,6 @@ float initialBrightnessVV = 0.0;
     NSError * videoError;
     AVCaptureDeviceInput * videoInput = [AVCaptureDeviceInput deviceInputWithDevice: self.videoDevice error:&videoError];
     [self.captureSession addInput:videoInput];
-    
-    // Add audio only when doing liveness
-    // TODO: Need to check why audio recording is lowered
-    if(self.doLivenessDetection){
-
-        AVCaptureDevice *audioCaptureDevice = [AVCaptureDevice defaultDeviceWithMediaType:AVMediaTypeAudio];
-        NSError *error = nil;
-        AVCaptureDeviceInput *audioInput = [AVCaptureDeviceInput deviceInputWithDevice:audioCaptureDevice error:&error];
-        if (audioInput){
-            [self.captureSession addInput:audioInput];
-            [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryPlayAndRecord withOptions:(AVAudioSessionCategoryOptionDefaultToSpeaker | AVAudioSessionCategoryOptionAllowBluetooth) error:nil];
-                  [[AVAudioSession sharedInstance] setActive:YES error:nil];
-            self.captureSession.usesApplicationAudioSession = YES;
-            self.captureSession.automaticallyConfiguresApplicationAudioSession = NO;
-        }
-        self.movieFileOutput = [[AVCaptureMovieFileOutput alloc] init];
-        Float64 TotalSeconds = 60;
-        int32_t preferredTimeScale = 30;
-        CMTime maxDuration = CMTimeMakeWithSeconds(TotalSeconds, preferredTimeScale);
-        self.movieFileOutput.maxRecordedDuration = maxDuration;
-        self.movieFileOutput.minFreeDiskSpaceLimit = 1024 * 1024;
-        if ([self.captureSession canAddOutput:self.movieFileOutput]){
-            [self.captureSession addOutput:self.movieFileOutput];
-            [self.captureSession setSessionPreset:AVCaptureSessionPresetMedium];
-        }
-        AVCaptureConnection *CaptureConnection = [self.movieFileOutput connectionWithMediaType:AVMediaTypeVideo];
-        if ([CaptureConnection isVideoOrientationSupported])
-        {
-            AVCaptureVideoOrientation orientation = AVCaptureVideoOrientationPortrait;
-            [CaptureConnection setVideoOrientation:orientation];
-        }
-    }
 }
 
 -(void) setupCameraCircle{
@@ -394,141 +220,44 @@ float initialBrightnessVV = 0.0;
 
 #pragma mark - Action Methods
 
--(void) playSound:(NSString*) lco{
-    NSLog(@"Play Voice Over");
-    if(self.doAudioPrompts && !self.cancelPlayback){
-        float time = [self.livenessChallengeTime floatValue];
-        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, time * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
-            [self.player stop];
-        });
-        NSBundle * podBundle = [NSBundle bundleForClass: self.classForCoder];
-        NSURL * bundleURL = [[podBundle resourceURL] URLByAppendingPathComponent:@"VoiceIt3-IosSDK.bundle"];
-        NSString* soundFilePath = [self.contentLanguage isEqualToString:@"es-ES"] ?
-        [NSString stringWithFormat:@"%@/%@",[[[NSBundle alloc] initWithURL:bundleURL] resourcePath], [self getSpanishPrompts:lco]] : [NSString stringWithFormat:@"%@/%@",[[[NSBundle alloc] initWithURL:bundleURL] resourcePath], lco];
-        NSURL *soundFileURL = [NSURL fileURLWithPath:soundFilePath];
-        NSError *error;
-        AVAudioSession *session = [AVAudioSession sharedInstance];
-        [session setCategory:AVAudioSessionCategoryPlayAndRecord withOptions:AVAudioSessionCategoryOptionDefaultToSpeaker error:nil];
-        self.player = [[AVAudioPlayer alloc] initWithContentsOfURL:soundFileURL error:&error];
-        self.player.numberOfLoops = 0; //Infinite
-        [self.player play];
-    }
-}
-
--(NSString*) getSpanishPrompts: (NSString*)lco{
-    NSLog(@"Play Spanish Prompts");
-    if([lco isEqualToString:@"FACE_DOWN.wav"])
-        return @"FACE_DOWN_ES.wav";
-    if([lco isEqualToString:@"FACE_LEFT.wav"])
-        return @"FACE_LEFT_ES.wav";
-    if([lco isEqualToString:@"FACE_RIGHT.wav"])
-        return @"FACE_RIGHT_ES.wav";
-    if([lco isEqualToString:@"FACE_TILT_LEFT.wav"])
-        return @"FACE_TILT_LEFT_ES.wav";
-    if([lco isEqualToString:@"FACE_TILT_RIGHT.wav"])
-        return @"FACE_TILT_RIGHT_ES.wav";
-    if([lco isEqualToString:@"FACE_NEUTRAL.wav"])
-        return @"FACE_NEUTRAL_ES.wav";
-    if([lco isEqualToString:@"FACE_UP.wav"])
-        return @"FACE_UP_ES.wav";
-    if([lco isEqualToString:@"LIVENESS_FAILED.wav"])
-        return @"LIVENESS_FAILED_ES.wav";
-    if([lco isEqualToString:@"LIVENESS_SUCCESS.wav"])
-        return @"LIVENESS_SUCCESS_ES.wav";
-    if([lco isEqualToString:@"LIVENESS_TRY_AGAIN.wav"])
-        return @"LIVENESS_TRY_AGAIN.wav";
-    if([lco isEqualToString:@"SMILE.wav"])
-        return @"SMILE_ES.wav";
-    return @"";
-}
-
--(void) illuminateLivenessChallengeOnCircle:(NSString*) lcoSignal{
-    NSLog(@"Illuminate Liveness Challenge On Circle");
-    [self playSound: [NSString stringWithFormat:@"%@.wav",lcoSignal]];
-    if ([lcoSignal isEqualToString:@"FACE_UP"]) {
-        self.progressCircle.path = [UIBezierPath bezierPathWithArcCenter: self.cameraCenterPoint radius:(self.backgroundWidthHeight / 2) startAngle: 1.2 * M_PI endAngle: 1.8 * M_PI clockwise:YES].CGPath;
-        self.progressCircle.drawsAsynchronously = YES;
-        self.progressCircle.borderWidth = 20;
-        self.progressCircle.fillColor =  [UIColor greenColor].CGColor;
-    } else if ([lcoSignal isEqualToString:@"FACE_DOWN"]) {
-        self.progressCircle.path = [UIBezierPath bezierPathWithArcCenter: self.cameraCenterPoint radius:(self.backgroundWidthHeight / 2) startAngle: 0.2 * M_PI endAngle: 0.8 * M_PI clockwise:YES].CGPath;
-        self.progressCircle.drawsAsynchronously = YES;
-        self.progressCircle.borderWidth = 20;
-        self.progressCircle.fillColor =  [UIColor greenColor].CGColor;
-    } else if ([lcoSignal isEqualToString:@"FACE_RIGHT"]) {
-        self.progressCircle.path = [UIBezierPath bezierPathWithArcCenter: self.cameraCenterPoint radius:(self.backgroundWidthHeight / 2) startAngle: 1.75 * M_PI endAngle: 0.25 * M_PI clockwise:YES].CGPath;
-        self.progressCircle.drawsAsynchronously = YES;
-        self.progressCircle.borderWidth = 20;
-        self.progressCircle.fillColor =  [UIColor greenColor].CGColor;
-    } else if ([lcoSignal isEqualToString:@"FACE_LEFT"]) {
-        self.progressCircle.path = [UIBezierPath bezierPathWithArcCenter: self.cameraCenterPoint radius:(self.backgroundWidthHeight / 2) startAngle: 0.75 * M_PI endAngle: 1.25 * M_PI clockwise:YES].CGPath;
-        self.progressCircle.borderWidth = 20;
-        self.progressCircle.drawsAsynchronously = YES;
-        self.progressCircle.fillColor =  [UIColor greenColor].CGColor;
-    } else if([lcoSignal isEqualToString:@"FACE_TILT_LEFT"]){
-        self.progressCircle.path = [UIBezierPath bezierPathWithArcCenter: self.cameraCenterPoint radius:(self.backgroundWidthHeight / 2) startAngle: -0.5 * M_PI endAngle:-M_PI clockwise:NO].CGPath;
-        self.progressCircle.borderWidth = 20;
-        self.progressCircle.drawsAsynchronously = YES;
-        self.progressCircle.fillColor =  [UIColor greenColor].CGColor;
-    } else if([lcoSignal isEqualToString:@"FACE_TILT_RIGHT"]){
-        self.progressCircle.path = [UIBezierPath bezierPathWithArcCenter: self.cameraCenterPoint radius:(self.backgroundWidthHeight / 2) startAngle: 0 endAngle: -0.4 * M_PI clockwise:NO].CGPath;
-        self.progressCircle.borderWidth = 20;
-        self.progressCircle.drawsAsynchronously = YES;
-        self.progressCircle.fillColor =  [UIColor greenColor].CGColor;
-    }  else if([lcoSignal isEqualToString:@"SMILE"]){
-        self.progressCircle.path = [UIBezierPath bezierPathWithArcCenter: self.cameraCenterPoint radius:(self.backgroundWidthHeight / 2) startAngle: 0 endAngle: 2*M_PI clockwise:NO].CGPath;
-        self.progressCircle.borderWidth = 20;
-        self.progressCircle.drawsAsynchronously = YES;
-        self.progressCircle.fillColor =  [UIColor greenColor].CGColor;
-    }
-}
-
-
 -(void) startDelayedAudioRecording:(NSTimeInterval)delayTime{
     NSLog(@"Start Delayed Audio Recording");
-    NSLog(@"|-doLivenessDetection = %d", self.doLivenessDetection);
-    NSLog(@"|-isChallengeRetrieved = %d", self.isChallengeRetrieved);
     NSLog(@"|-continueRunning = %d", self.continueRunning);
 
-    if(self.doLivenessDetection && self.isChallengeRetrieved) {
-        [self startRecordingVideo];
-    } else {
-        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, delayTime * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
-            if(self.continueRunning){
-                [self setMessage:[ResponseManager getMessage:@"VERIFY" variable:self.thePhrase]];
-                dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 0.5 * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
-                    if(self.continueRunning){
-                        [self startRecordingAudio];
-                    }
-                });
-            }
-        });
-    }
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, delayTime * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
+        if(self.continueRunning){
+            [self setMessage:[ResponseManager getMessage:@"VERIFY" variable:self.thePhrase]];
+            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 0.5 * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
+                if(self.continueRunning){
+                    [self startRecordingAudio];
+                }
+            });
+        }
+    });
 }
 
 -(void) startVerificationProcess{
     NSLog(@"Start Verification Process");
-    NSLog(@"|-doLivenessDetection = %d", self.doLivenessDetection);
     NSLog(@"|-lookingIntoCam = %d", self.lookingIntoCam);
     NSLog(@"|-isProcessing = %d", self.isProcessing);
     if (!self.continueRunning) {
         return;
     }
-    
+
     //Check if User Id is correct
     if (![Utilities checkUserId:self.userToVerifyUserId]){
         NSString *response = @"{\"responseCode\":\"CREDENTIAL_ERROR\",\"message\":\"Please make sure your userId and credentials are correct\"}";
         [self exitWithResponse:response];
         return;
     }
-    
+
     //Check if there is Internet Connection
     if (![Utilities checkNetwork]){
         NSString *response = @"{\"responseCode\":\"NETWORK_ERROR\",\"message\":\"Please make sure you are connected to the internet\"}";
         [self exitWithResponse:response];
         return;
     }
-    
+
         [self.myVoiceIt getAllVideoEnrollments:_userToVerifyUserId callback:^(NSString * jsonResponse){
             NSDictionary *jsonObj = [Utilities getJSONObject:jsonResponse];
             NSString * responseCode = [jsonObj objectForKey:@"responseCode"];
@@ -537,14 +266,8 @@ float initialBrightnessVV = 0.0;
                 if(enrollmentsCount < 3){
                     [self notEnoughEnrollments:@"{\"responseCode\":\"TVER\",\"message\":\"Not enough video enrollments\"}"];
                 } else {
-                    // Start Audio recording without Liveness
-                    if(!self.doLivenessDetection && self.lookingIntoCam){
+                    if(self.lookingIntoCam){
                         [self startDelayedAudioRecording:0.4];
-                    } else {
-                        // Show Livness Instructions before recording Video
-                        if(!self.isProcessing){
-                            [self setMessage: self.livenessInstruction];
-                        }
                     }
                 }
             } else {
@@ -555,46 +278,23 @@ float initialBrightnessVV = 0.0;
 
 -(void) startRecordingVideo {
     NSLog(@"Start Recording Video");
-    NSLog(@"|-doLivenessDetection = %d", self.doLivenessDetection);
-    NSLog(@"|-isChallengeRetrieved = %d", self.isChallengeRetrieved);
     NSLog(@"|-continueRunning = %d", self.continueRunning);
 
     self.isRecording = YES;
     self.isProcessing = YES;
-    
-    if(self.doLivenessDetection && self.isChallengeRetrieved){
-        // Liveness
-        [self startRecordingVideoWithLivenessChallenges];
-    } else {
-        // No Livness
-        [self startWritingToVideoFile];
-        [self setMessage:[ResponseManager getMessage:@"VERIFY" variable:self.thePhrase]];
-        
-        // Start Progress Circle Around Face Animation
-        [self animateProgressCircleForAudioRecording];
-        
-        // Stop recording video/Audio Recording after 5 seconds
-        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 5.0 * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
-            if(self.continueRunning){
-                if (!self.doLivenessDetection) {
-                    [self stopRecordingAudio];
-                }
-            }
-        });
-    }
-}
 
--(void) startRecordingVideoWithLivenessChallenges{
-    NSLog(@"Start Recording Video With Liveness Challenges");
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, [self.livenessChallengeTime floatValue] * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
-        [self setMessage:[ResponseManager getMessage:@"VERIFY" variable:self.thePhrase]];
-        [self animateProgressCircleForAudioRecording];
+    [self startWritingToVideoFile];
+    [self setMessage:[ResponseManager getMessage:@"VERIFY" variable:self.thePhrase]];
+
+    // Start Progress Circle Around Face Animation
+    [self animateProgressCircleForAudioRecording];
+
+    // Stop recording video/Audio Recording after 5 seconds
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 5.0 * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
+        if(self.continueRunning){
+            [self stopRecordingAudio];
+        }
     });
-    [self setLivenessChallengeMessages];
-    // Setup for callback to on completed video recording captureOutput
-    NSString * outputPath = [Utilities pathForTemporaryFileWithSuffix:@"mp4"];
-    NSURL * outputURL = [[NSURL alloc] initFileURLWithPath:outputPath];
-    [self.movieFileOutput startRecordingToOutputFileURL:outputURL recordingDelegate:self];
 }
 
 - (UIImage *) imageFromCIImage:(CIImage *)ciImage{
@@ -647,9 +347,6 @@ float initialBrightnessVV = 0.0;
 
 -(void) animateProgressCircleForAudioRecording{
     NSLog(@"Animate Progress Circle For Audio Recording");
-    if(self.doLivenessDetection){
-        [self clearCircleAnimations];
-      }
     dispatch_async(dispatch_get_main_queue(), ^{
         self.progressCircle.strokeColor = [Styles getMainCGColor];
         CABasicAnimation *animation = [CABasicAnimation animationWithKeyPath:@"strokeEnd"];
@@ -705,33 +402,10 @@ float initialBrightnessVV = 0.0;
 
 - (IBAction) cancelClicked:(id)sender{
     NSLog(@"Canceled/Continue Button Tapped");
-    if(!self.doLivenessDetection){
-        self.cancelPlayback = YES;
-        self.continueRunning = NO;
-        [self dismissViewControllerAnimated:YES completion:^{
-            [self userVerificationCancelled]();
-        }];
-    } else {
-        // Liveness
-        if(self.verificationStarted == YES && [self.cancelButton.titleLabel.text isEqual:@"Continue"]){
-            [self startRecordingVideo];
-        }
-        if(self.verificationStarted == NO || [self.cancelButton.titleLabel.text isEqual:@"Cancel"]){
-            self.cancelPlayback = YES;
-            self.continueRunning = NO;
-            [self cleanupEverything];
-            [self.player stop];
-            [self dismissViewControllerAnimated:YES completion:^{
-                [self userVerificationCancelled]();
-            }];
-        }
-        if([self.cancelButton.titleLabel.text isEqual:@"Done"]){
-            self.cancelPlayback = YES;
-            [self dismissViewControllerAnimated:YES completion:^{
-                [self userVerificationSuccessful](0,0,self.result);
-            }];
-        }
-    }
+    self.continueRunning = NO;
+    [self dismissViewControllerAnimated:YES completion:^{
+        [self userVerificationCancelled]();
+    }];
 }
 
 #pragma mark - Camera Delegate Methods
@@ -740,117 +414,36 @@ float initialBrightnessVV = 0.0;
 -(void)    captureOutput:(AVCaptureOutput *)output
 didOutputMetadataObjects:(NSArray<__kindof AVMetadataObject *> *)metadataObjects
           fromConnection:(AVCaptureConnection *)connection{
-    
-//    NSLog(@"lookingIntoCam = %d", self.lookingIntoCam);
-//    NSLog(@"verificationStarted = %d", self.verificationStarted);
-//    NSLog(@"doLivenessDetection = %d", self.doLivenessDetection);
-//    NSLog(@"isRecording = %d", self.isRecording);
-//    NSLog(@"isProcessing = %d", self.isProcessing);
-//    NSLog(@"isSuccess = %d", self.isSuccess);
 
-    if(self.doLivenessDetection){
-        BOOL faceFound = NO;
-        for(AVMetadataObject *metadataObject in metadataObjects) {
-            if([metadataObject.type isEqualToString:AVMetadataObjectTypeFace]) {
-                faceFound = YES;
-                AVMetadataObject * face = [self.previewLayer transformedMetadataObjectForMetadataObject:metadataObject];
-                [Utilities showFaceRectangle:self.faceRectangleLayer face:face];
-            }
+    BOOL faceFound = NO;
+    for(AVMetadataObject *metadataObject in metadataObjects) {
+        if([metadataObject.type isEqualToString:AVMetadataObjectTypeFace]) {
+            faceFound = YES;
+            AVMetadataObject * face = [self.previewLayer transformedMetadataObjectForMetadataObject:metadataObject];
+            [Utilities showFaceRectangle:self.faceRectangleLayer face:face];
         }
-        
-        if(faceFound) {
-            self.lookingIntoCamCounter += 1;
-            self.lookingIntoCam = self.lookingIntoCamCounter > MAX_TIME_TO_WAIT_TILL_FACE_FOUND;
-            if (self.lookingIntoCam && !self.verificationStarted) {
-                self.verificationStarted = YES;
-                [self startVerificationProcess];
-            }
-        } else {
-            self.lookingIntoCam = NO;
-            self.lookingIntoCamCounter = 0;
-           [self.faceRectangleLayer setHidden:YES];
-        }
-        
-        if(self.doLivenessDetection && !self.isRecording && !self.lookingIntoCam && !self.isProcessing && [self.progressView isHidden] && !self.isSuccess){
-            [self setMessage:[ResponseManager getMessage:@"LOOK_INTO_CAM"]];
-            self.verificationStarted = NO;
-            [self.cancelButton setTitle:[ResponseManager getMessage:@"Cancel"] forState:UIControlStateNormal];
-        }
-        
-        if(self.doLivenessDetection && !self.isRecording && self.lookingIntoCam && !self.isProcessing){
-            if (!self.isSuccess) {
-                [self setMessage:self.livenessInstruction];
-                [self.cancelButton setTitle:[ResponseManager getMessage:@"Continue"] forState:UIControlStateNormal];
-            } else {
-                [self.cancelButton setHidden:YES];
-            }
-            
-        }
-        
-        if(self.isProcessing){
-            [self.cancelButton setTitle:[ResponseManager getMessage:@"Cancel"] forState:UIControlStateNormal];
-        }
-        
-        if(self.isSuccess){
-            [self.cancelButton setTitle:[ResponseManager getMessage:@"Done"] forState:UIControlStateNormal];
+    }
+
+    if(faceFound) {
+        self.lookingIntoCamCounter += 1;
+        self.lookingIntoCam = self.lookingIntoCamCounter > MAX_TIME_TO_WAIT_TILL_FACE_FOUND;
+        if (self.lookingIntoCam && !self.verificationStarted) {
+            self.verificationStarted = YES;
+            [self startVerificationProcess];
         }
     } else {
-        // No Liveness
-        BOOL faceFound = NO;
-        for(AVMetadataObject *metadataObject in metadataObjects) {
-            if([metadataObject.type isEqualToString:AVMetadataObjectTypeFace]) {
-                faceFound = YES;
-                AVMetadataObject * face = [self.previewLayer transformedMetadataObjectForMetadataObject:metadataObject];
-                [Utilities showFaceRectangle:self.faceRectangleLayer face:face];
-            }
-        }
-        
-        if(faceFound) {
-            self.lookingIntoCamCounter += 1;
-            self.lookingIntoCam = self.lookingIntoCamCounter > MAX_TIME_TO_WAIT_TILL_FACE_FOUND;
-            if (self.lookingIntoCam && !self.verificationStarted) {
-                self.verificationStarted = YES;
-                if(!self.doLivenessDetection){
-                    [self startVerificationProcess];
-                }
-            }
-        } else {
-            self.lookingIntoCam = NO;
-            NSLog(@"lookingIntoCam = %d", self.lookingIntoCam);
-            self.lookingIntoCamCounter = 0;
-            [self.faceRectangleLayer setHidden:YES];
-        }
+        self.lookingIntoCam = NO;
+        self.lookingIntoCamCounter = 0;
+        [self.faceRectangleLayer setHidden:YES];
     }
-}
-
-- (void)              captureOutput:(AVCaptureFileOutput *)captureOutput
-didFinishRecordingToOutputFileAtURL:(NSURL *)outputFileURL
-                    fromConnections:(NSArray *)connections
-                              error:(NSError *)error
-{
-    NSLog(@"Making Video Call to Liveness Services");
-    if (!self.continueRunning) {
-        return;
-    }
-    [self.myVoiceIt videoVerificationWithLiveness:self.lcoId userId: self.userToVerifyUserId contentLanguage:self.contentLanguage videoPath:[outputFileURL path] phrase:self.thePhrase pageCategory:@"verification" callback:^(NSString * result) {
-        [self handleLivenessResponse: result];
-    }];
-    
 }
 
 - (void) captureOutput:(AVCaptureOutput *)captureOutput
  didOutputSampleBuffer:(CMSampleBufferRef)sampleBuffer
         fromConnection:(AVCaptureConnection *)connection{
-    
-//    NSLog(@"lookingIntoCam = %d", self.lookingIntoCam);
-//    NSLog(@"verificationStarted = %d", self.verificationStarted);
-//    NSLog(@"doLivenessDetection = %d", self.doLivenessDetection);
-//    NSLog(@"isRecording = %d", self.isRecording);
-//    NSLog(@"isProcessing = %d", self.isProcessing);
-//    NSLog(@"isSuccess = %d", self.isSuccess);
-    
-    // Don't do any analysis when not looking into the camera with no liveness test enabled
-    if(!self.lookingIntoCam && !self.doLivenessDetection && !self.isProcessing){
+
+    // Don't do any analysis when not looking into the camera
+    if(!self.lookingIntoCam && !self.isProcessing){
         dispatch_async(dispatch_get_main_queue(), ^{
             [self.messageLabel setText: [ResponseManager getMessage:@"LOOK_INTO_CAM"]];
             self.verificationStarted = NO;
@@ -858,7 +451,7 @@ didFinishRecordingToOutputFileAtURL:(NSURL *)outputFileURL
         return;
     }
     // When enough looking into camera time has passed and recording has not yet begun
-    if(self.lookingIntoCamCounter > 5 && !self.imageIsSaved && !self.doLivenessDetection){
+    if(self.lookingIntoCamCounter > 5 && !self.imageIsSaved){
         // Convert to CIPixelBuffer for faceDetector
         CVPixelBufferRef pixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer);
         if (pixelBuffer == NULL) {
@@ -1015,10 +608,6 @@ didFinishRecordingToOutputFileAtURL:(NSURL *)outputFileURL
     [self setAudioSessionInactive];
     [self cleanupCaptureSession];
     self.continueRunning = NO;
-    if(self.doLivenessDetection){
-        [self.player stop];
-        self.player = nil;
-    }
 }
 
 //Reset circle for Animation

--- a/VoiceIt2-IosSDK/Classes/VoiceItAPITwo.h
+++ b/VoiceIt2-IosSDK/Classes/VoiceItAPITwo.h
@@ -96,12 +96,6 @@
                imageData:(NSData *)imageData
                 callback:(void (^)(NSString *))callback;
 
-- (void)faceVerificationWithLiveness:(NSString *)userId
-                           videoPath:(NSString *)videoPath
-                            callback:(void (^)(NSString *))callback
-                               lcoId:(NSString *) lcoId
-                        pageCategory:(NSString *) pageCategory;
-
 - (void)videoVerification:(NSString *)userId
           contentLanguage:(NSString *)contentLanguage
                 videoPath:(NSString *)videoPath
@@ -115,14 +109,6 @@
                 audioPath:(NSString *)audioPath
                    phrase:(NSString *)phrase
                  callback:(void (^)(NSString *))callback;
-
-- (void)videoVerificationWithLiveness:(NSString *)lcoId
-                               userId:(NSString *)userId
-                      contentLanguage:(NSString *)contentLanguage
-                            videoPath:(NSString *)videoPath
-                               phrase:(NSString *)phrase
-                         pageCategory:(NSString *) pageCategory
-                             callback:(void (^)(NSString *))callback;
 
 
 #pragma mark - Identification API Calls
@@ -169,19 +155,14 @@
                userVerificationFailed:(void (^)(float, NSString *))userVerificationFailed;
 
 - (void)encapsulatedFaceVerification:(NSString *)userId
-                 doLivenessDetection:(bool)doLivenessDetection
-                      doAudioPrompts:(bool)doAudioPrompts
-                      contentLanguage:(NSString *)contentLanguage
+                     contentLanguage:(NSString *)contentLanguage
            userVerificationCancelled:(void (^)(void))userVerificationCancelled
           userVerificationSuccessful:(void (^)(float, NSString *))userVerificationSuccessful
               userVerificationFailed:(void (^)(float, NSString *))userVerificationFailed;
 
 - (void)encapsulatedFaceVerification:(NSString *)userId
-                 doLivenessDetection:(bool)doLivenessDetection
-                      doAudioPrompts:(bool)doAudioPrompts
                      numFailsAllowed:(int)numFailsAllowed
                      contentLanguage:(NSString *)contentLanguage
-       livenessChallengeFailsAllowed:(int)livenessChallengeFailsAllowed
            userVerificationCancelled:(void (^)(void))userVerificationCancelled
           userVerificationSuccessful:(void (^)(float, NSString *))userVerificationSuccessful
               userVerificationFailed:(void (^)(float, NSString *))userVerificationFailed;
@@ -189,8 +170,6 @@
 - (void)encapsulatedVideoVerification:(NSString *)userId
                       contentLanguage:(NSString *)contentLanguage
                      voicePrintPhrase:(NSString *)voicePrintPhrase
-                  doLivenessDetection:(bool)doLivenessDetection
-                       doAudioPrompts:(bool)doAudioPrompts
             userVerificationCancelled:(void (^)(void))userVerificationCancelled
            userVerificationSuccessful:(void (^)(float, float, NSString *))userVerificationSuccessful
                userVerificationFailed:(void (^)(float, float, NSString *))userVerificationFailed;
@@ -198,10 +177,7 @@
 - (void)encapsulatedVideoVerification:(NSString *)userId
                       contentLanguage:(NSString *)contentLanguage
                      voicePrintPhrase:(NSString *)voicePrintPhrase
-                  doLivenessDetection:(bool)doLivenessDetection
-                       doAudioPrompts:(bool)doAudioPrompts
                       numFailsAllowed:(int)numFailsAllowed
-         livenessChallengeFailsAllowed:(int)livenessChallengeFailsAllowed
             userVerificationCancelled:(void (^)(void))userVerificationCancelled
            userVerificationSuccessful:(void (^)(float, float, NSString *))userVerificationSuccessful
                userVerificationFailed:(void (^)(float, float, NSString *))userVerificationFailed;
@@ -223,12 +199,5 @@
            userIdentificationSuccessful:(void (^)(float, NSString *, NSString *))userIdentificationSuccessful
                userIdentificationFailed:(void (^)(float, NSString *))userIdentificationFailed;
 
-
-#pragma mark - Liveness API Calls
-- (void)getLivenessID:(NSString *)userId
-          countryCode:(NSString *) countryCode
-             callback:(void (^)(NSString *))callback
-             onFailed:(void(^)(NSError *))onFailed
-          pageCateory:(NSString *) pageCategory;
 
 @end


### PR DESCRIPTION
## Summary
- Remove all liveness server (`liveness.voiceit.io`) references and Liveness Challenge Object (LCO) flow
- Simplify `encapsulatedFaceVerification` and `encapsulatedVideoVerification` signatures (removed `doLivenessDetection`, `doAudioPrompts`, `livenessChallengeFailsAllowed` params)
- Remove liveness methods from VoiceItAPITwo (`faceVerificationWithLiveness:`, `videoVerificationWithLiveness:`, `getLivenessID:`, `buildLivenessURL:`)
- Clean up FaceVerificationViewController and VideoVerificationViewController (remove LCO challenge display, liveness audio prompts, challenge circle animations)
- Remove liveness prompt strings and podspec liveness mention

## Test plan
- [ ] Verify face verification flow works without liveness
- [ ] Verify video verification flow works without liveness
- [ ] Confirm no remaining references to `liveness.voiceit.io`

🤖 Generated with [Claude Code](https://claude.com/claude-code)